### PR TITLE
Data key optimization

### DIFF
--- a/data_key_test.go
+++ b/data_key_test.go
@@ -1,0 +1,39 @@
+package mmdbwriter
+
+import (
+	"testing"
+
+	"github.com/maxmind/mmdbwriter/mmdbtype"
+)
+
+func BenchmarkKeyGeneration(b *testing.B) {
+	b.Run("small value", func(b *testing.B) {
+		value := mmdbtype.String("some test value that is not too long")
+		writer := newKeyWriter()
+
+		for i := 0; i < b.N; i++ {
+			_, err := writer.key(value)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+	b.Run("large value", func(b *testing.B) {
+		value := mmdbtype.Map{
+			"string": mmdbtype.String("some string value"),
+			"number": mmdbtype.Uint64(123456789),
+			"slice": mmdbtype.Slice{
+				mmdbtype.String("some string value"),
+				mmdbtype.Uint64(123456789),
+			},
+		}
+		writer := newKeyWriter()
+
+		for i := 0; i < b.N; i++ {
+			_, err := writer.key(value)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}

--- a/data_key_test.go
+++ b/data_key_test.go
@@ -3,6 +3,8 @@ package mmdbwriter
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/maxmind/mmdbwriter/mmdbtype"
 )
 
@@ -36,4 +38,30 @@ func BenchmarkKeyGeneration(b *testing.B) {
 			}
 		}
 	})
+}
+
+func TestKeyWriter(t *testing.T) {
+	assertions := assert.New(t)
+	writer := newKeyWriter()
+
+	valueOne := mmdbtype.String("some test value to be turned into a key")
+	valueTwo := mmdbtype.String("another test value to be turned into a key")
+
+	keyOne, err := writer.key(valueOne)
+
+	assertions.NoErrorf(err, "expected no error")
+
+	keyTwo, err := writer.key(valueTwo)
+
+	assertions.NoErrorf(err, "expected no error")
+
+	// The keys should be uniformly distributed, so the change of this test breaking at random is 1 in 2^64.
+	assertions.NotEqual(keyOne, keyTwo, "expected keys to be different")
+
+	keyOneAgain, err := writer.key(valueOne)
+
+	assertions.NoErrorf(err, "expected no error")
+
+	// Test this after keyTwo was created to make sure the state is not being reused.
+	assertions.Equal(keyOne, keyOneAgain, "expected keys to be the same for the same value")
 }

--- a/data_key_test.go
+++ b/data_key_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func BenchmarkKeyGeneration(b *testing.B) {
-	b.Run("small value", func(b *testing.B) {
+	b.Run("simple value", func(b *testing.B) {
 		value := mmdbtype.String("some test value that is not too long")
 		writer := newKeyWriter()
 
@@ -18,7 +18,7 @@ func BenchmarkKeyGeneration(b *testing.B) {
 			}
 		}
 	})
-	b.Run("large value", func(b *testing.B) {
+	b.Run("nested value", func(b *testing.B) {
 		value := mmdbtype.Map{
 			"string": mmdbtype.String("some string value"),
 			"number": mmdbtype.Uint64(123456789),

--- a/data_map.go
+++ b/data_map.go
@@ -2,7 +2,7 @@ package mmdbwriter
 
 import "github.com/maxmind/mmdbwriter/mmdbtype"
 
-type dataMapKey string
+type dataMapKey uint64
 
 // Please note, if you change the order of these fields, please check
 // alignment as we end up storing quite a few in memory.

--- a/data_map_test.go
+++ b/data_map_test.go
@@ -17,11 +17,13 @@ func TestDataMap(t *testing.T) {
 	dmv, err := dm.store(v)
 	require.NoError(t, err)
 
+	valueKey, _ := dm.keyWriter.key(v)
+
 	assert.Equal(
 		t,
 		&dataMapValue{
 			data:     v,
-			key:      123456789,
+			key:      dataMapKey(valueKey),
 			refCount: 1,
 		},
 		dmv,

--- a/data_map_test.go
+++ b/data_map_test.go
@@ -3,9 +3,10 @@ package mmdbwriter
 import (
 	"testing"
 
-	"github.com/maxmind/mmdbwriter/mmdbtype"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/maxmind/mmdbwriter/mmdbtype"
 )
 
 func TestDataMap(t *testing.T) {
@@ -19,9 +20,8 @@ func TestDataMap(t *testing.T) {
 	assert.Equal(
 		t,
 		&dataMapValue{
-			data: v,
-			key: "\x87\x02\xf53\x8b\x96\xfdǻQ\x97\x9c\xe2\xcc\\\xda\xf2\xb1\xd7" +
-				"\xc1L\xc5l\xfd\x83\xfc\x97\xd6\x03\xf5\xedr",
+			data:     v,
+			key:      123456789,
 			refCount: 1,
 		},
 		dmv,

--- a/data_map_test.go
+++ b/data_map_test.go
@@ -2,6 +2,7 @@ package mmdbwriter
 
 import (
 	"testing"
+	"unsafe"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -47,4 +48,9 @@ func TestDataMap(t *testing.T) {
 	dm.remove(dmv)
 	_, ok := dm.data[dmv.key]
 	assert.False(t, ok, "map value removed when refCount drops to 0")
+}
+
+func TestMapValueAlignment(t *testing.T) {
+	t.Logf("Alignment of dataMapValue: %d", unsafe.Alignof(dataMapValue{}))
+	t.Logf("Size of dataMapValue: %d", unsafe.Sizeof(dataMapValue{}))
 }

--- a/data_section.go
+++ b/data_section.go
@@ -52,7 +52,7 @@ func (dw *dataWriter) maybeWrite(value *dataMapValue) (int, error) {
 }
 
 func (dw *dataWriter) WriteOrWritePointer(t mmdbtype.DataType) (int64, error) {
-	keyBytes, err := dw.keyWriter.key(t)
+	key, err := dw.keyWriter.key(t)
 	if err != nil {
 		return 0, err
 	}
@@ -60,18 +60,13 @@ func (dw *dataWriter) WriteOrWritePointer(t mmdbtype.DataType) (int64, error) {
 	var ok bool
 	if dw.usePointers {
 		var written writtenType
-		written, ok = dw.offsets[dataMapKey(keyBytes)]
+		written, ok = dw.offsets[dataMapKey(key)]
 		if ok && written.size > written.pointer.WrittenSize() {
 			// Only use a pointer if it would take less space than writing the
 			// type again.
 			return written.pointer.WriteTo(dw)
 		}
 	}
-	// We can't use the pointers[dataMapKey(keyBytes)] optimization to
-	// avoid an allocation below as the backing buffer for key may change when
-	// we call t.WriteTo. That said, this is the less common code path
-	// so it doesn't matter too much.
-	key := dataMapKey(keyBytes)
 
 	// TODO: A possible optimization here for simple types would be to just
 	// write key to the dataWriter. This won't necessarily work for Map and
@@ -84,7 +79,7 @@ func (dw *dataWriter) WriteOrWritePointer(t mmdbtype.DataType) (int64, error) {
 		return size, err
 	}
 
-	dw.offsets[key] = writtenType{
+	dw.offsets[dataMapKey(key)] = writtenType{
 		pointer: mmdbtype.Pointer(offset),
 		size:    size,
 	}


### PR DESCRIPTION
Two changes:
- Changed the representation of the internal `dataMapKey` to a `uint64` instead of a `string`.
- Changed the `keyWriter` to use a [`maphash.Hash`](https://pkg.go.dev/hash/maphash#Hash) instead of a sha256 since there is no need for cryptographically secure hashing on a deduplication key. This could be made configurable if there is actually such a use case.

As noted in the comment, I checked the effect of this change on the size and alignment of `dataMapValue`. The alignment remains at 8 bytes, and the size went down from 40 to 32 bytes due to `string` requiring two words. A test was added to log these properties since those should be kept under control.

Also includes a benchmark for the new `keyWriter.key` method. Here are the results from the original implementation, the one proposed by this PR and a few others that I tried:
```
# Result using buffered sha256
BenchmarkKeyGeneration/simple_value-12            3940114               299.3 ns/op            64 B/op          3 allocs/op
BenchmarkKeyGeneration/nested_value-12            1000000              1052 ns/op             272 B/op         14 allocs/op

# Result using unbuffered fnv.New64 and bytes return type
BenchmarkKeyGeneration/simple_value-12            6729507               188.6 ns/op            96 B/op          6 allocs/op
BenchmarkKeyGeneration/nested_value-12            1015862              1166 ns/op             360 B/op         39 allocs/op

# Result using buffered fnv.New64 and uint64 return type
BenchmarkKeyGeneration/simple_value-12           10141742               114.7 ns/op            32 B/op          2 allocs/op
BenchmarkKeyGeneration/nested_value-12            1547077               777.9 ns/op           240 B/op         13 allocs/op

# Result using maphash.Hash (internally buffered) and uint64 return type
BenchmarkKeyGeneration/simple_value-12           14879239                78.18 ns/op           32 B/op          2 allocs/op
BenchmarkKeyGeneration/nested_value-12            1629522               714.8 ns/op           240 B/op         13 allocs/op
```

The change causes a 30% improvement for nested values and up to 70% improvement for simple values.

Also a point of notice, converting a `[]byte` to `string` causes a new allocation and copy of the bytes every time ([example on playground](https://go.dev/play/p/QkwpY5Bmixk)) while using a `uint64` makes the conversion to `dataMapKey` a noop (see [here](https://godbolt.org/z/edrszvfqx) that it is gone after compilation). So this change also makes the other functions that use the key more efficient.