### PR TITLE
Reduce unnecessary key generation when value does not change

### DIFF
--- a/data_map.go
+++ b/data_map.go
@@ -57,6 +57,11 @@ func (dm *dataMap) store(v mmdbtype.DataType) (*dataMapValue, error) {
 // remove removes a reference to the value. If the reference count
 // drops to zero, the value is removed from the dataMap.
 func (dm *dataMap) remove(v *dataMapValue) {
+	// This is here mostly so that we don't have to guard against it
+	// elsewhere.
+	if v == nil {
+		return
+	}
 	v.refCount--
 
 	if v.refCount == 0 {

--- a/mmdbtype/types.go
+++ b/mmdbtype/types.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"math/big"
 	"math/bits"
+	"reflect"
 	"sort"
 )
 
@@ -262,6 +263,10 @@ func (t Map) Equal(other DataType) bool {
 		return false
 	}
 
+	if reflect.ValueOf(t).Pointer() == reflect.ValueOf(otherT).Pointer() {
+		return true
+	}
+
 	for k, v := range t {
 		if ov, ok := otherT[k]; !ok || !v.Equal(ov) {
 			return false
@@ -449,6 +454,10 @@ func (t Slice) Equal(other DataType) bool {
 
 	if len(t) != len(otherT) {
 		return false
+	}
+
+	if reflect.ValueOf(t).Pointer() == reflect.ValueOf(otherT).Pointer() {
+		return true
 	}
 
 	for i, v := range t {

--- a/mmdbtype/types.go
+++ b/mmdbtype/types.go
@@ -51,6 +51,8 @@ type DataType interface {
 // Bool is the MaxMind DB boolean type.
 type Bool bool
 
+var _ DataType = (*Bool)(nil)
+
 // Copy the value.
 func (t Bool) Copy() DataType { return t }
 
@@ -72,6 +74,8 @@ func (t Bool) WriteTo(w writer) (int64, error) {
 
 // Bytes is the MaxMind DB bytes type.
 type Bytes []byte
+
+var _ DataType = Bytes(nil)
 
 // Copy the value.
 func (t Bytes) Copy() DataType {
@@ -106,6 +110,8 @@ func (t Bytes) WriteTo(w writer) (int64, error) {
 // Float32 is the MaxMind DB float type.
 type Float32 float32
 
+var _ DataType = (*Float32)(nil)
+
 // Copy the value.
 func (t Float32) Copy() DataType { return t }
 
@@ -134,6 +140,8 @@ func (t Float32) WriteTo(w writer) (int64, error) {
 // Float64 is the MaxMind DB double type.
 type Float64 float64
 
+var _ DataType = (*Float64)(nil)
+
 // Copy the value.
 func (t Float64) Copy() DataType { return t }
 
@@ -161,6 +169,8 @@ func (t Float64) WriteTo(w writer) (int64, error) {
 
 // Int32 is the MaxMind DB signed 32-bit integer type.
 type Int32 int32
+
+var _ DataType = (*Int32)(nil)
 
 // Copy the value.
 func (t Int32) Copy() DataType { return t }
@@ -193,6 +203,8 @@ func (t Int32) WriteTo(w writer) (int64, error) {
 
 // Map is the MaxMind DB map type.
 type Map map[String]DataType
+
+var _ DataType = Map(nil)
 
 // Copy makes a deep copy of the Map.
 func (t Map) Copy() DataType {
@@ -248,6 +260,8 @@ func (t Map) WriteTo(w writer) (int64, error) {
 // should not use this type in data structures that you pass to methods on
 // mmdbwriter.Tree. Doing so may result in a corrupt database.
 type Pointer uint32
+
+var _ DataType = (*Pointer)(nil)
 
 // Copy the value.
 func (t Pointer) Copy() DataType { return t }
@@ -354,6 +368,8 @@ func (t Pointer) WriteTo(w writer) (int64, error) {
 // Slice is the MaxMind DB array type.
 type Slice []DataType
 
+var _ DataType = Slice(nil)
+
 // Copy makes a deep copy of the Slice.
 func (t Slice) Copy() DataType {
 	newSlice := make(Slice, len(t))
@@ -391,6 +407,8 @@ func (t Slice) WriteTo(w writer) (int64, error) {
 // String is the MaxMind DB string type.
 type String string
 
+var _ DataType = (*String)(nil)
+
 // Copy the value.
 func (t String) Copy() DataType { return t }
 
@@ -419,6 +437,8 @@ func (t String) WriteTo(w writer) (int64, error) {
 
 // Uint16 is the MaxMind DB unsigned 16-bit integer type.
 type Uint16 uint16
+
+var _ DataType = (*Uint16)(nil)
 
 // Copy the value.
 func (t Uint16) Copy() DataType { return t }
@@ -452,6 +472,8 @@ func (t Uint16) WriteTo(w writer) (int64, error) {
 // Uint32 is the MaxMind DB unsigned 32-bit integer type.
 type Uint32 uint32
 
+var _ DataType = (*Uint32)(nil)
+
 // Copy the value.
 func (t Uint32) Copy() DataType { return t }
 
@@ -483,6 +505,8 @@ func (t Uint32) WriteTo(w writer) (int64, error) {
 
 // Uint64 is the MaxMind DB unsigned 64-bit integer type.
 type Uint64 uint64
+
+var _ DataType = (*Uint64)(nil)
 
 // Copy the value.
 func (t Uint64) Copy() DataType { return t }
@@ -516,6 +540,8 @@ func (t Uint64) WriteTo(w writer) (int64, error) {
 
 // Uint128 is the MaxMind DB unsigned 128-bit integer type.
 type Uint128 big.Int
+
+var _ DataType = (*Uint128)(nil)
 
 // Copy make a deep copy of the Uint128.
 func (t *Uint128) Copy() DataType {

--- a/mmdbtype/types_test.go
+++ b/mmdbtype/types_test.go
@@ -214,6 +214,232 @@ func TestUint128(t *testing.T) {
 	validateEncoding(t, uints)
 }
 
+func TestEqual(t *testing.T) {
+	sameMap := Map{"same": String("map")}
+	sameSlice := Slice{String("same")}
+	tests := []struct {
+		name   string
+		a      DataType
+		b      DataType
+		expect bool
+	}{
+		{
+			name:   "Bool same",
+			a:      Bool(true),
+			b:      Bool(true),
+			expect: true,
+		},
+		{
+			name:   "Bool different",
+			a:      Bool(false),
+			b:      Bool(true),
+			expect: false,
+		},
+		{
+			name:   "Bytes same",
+			a:      Bytes([]byte{1}),
+			b:      Bytes([]byte{1}),
+			expect: true,
+		},
+		{
+			name:   "Bytes different",
+			a:      Bytes([]byte{1}),
+			b:      Bytes([]byte{0}),
+			expect: false,
+		},
+		{
+			name:   "Bytes different length",
+			a:      Bytes([]byte{1, 1}),
+			b:      Bytes([]byte{1}),
+			expect: false,
+		},
+		{
+			name:   "Float32 same",
+			a:      Float32(1),
+			b:      Float32(1),
+			expect: true,
+		},
+		{
+			name:   "Float32 different",
+			a:      Float32(1),
+			b:      Float32(0),
+			expect: false,
+		},
+		{
+			name:   "Float64 same",
+			a:      Float64(1),
+			b:      Float64(1),
+			expect: true,
+		},
+		{
+			name:   "Float64 different",
+			a:      Float64(1),
+			b:      Float64(0),
+			expect: false,
+		},
+		{
+			name:   "Int32 same",
+			a:      Int32(1),
+			b:      Int32(1),
+			expect: true,
+		},
+		{
+			name:   "Int32 different",
+			a:      Int32(1),
+			b:      Int32(0),
+			expect: false,
+		},
+		{
+			name:   "Pointer same",
+			a:      Pointer(1),
+			b:      Pointer(1),
+			expect: true,
+		},
+		{
+			name:   "Pointer different",
+			a:      Pointer(1),
+			b:      Pointer(0),
+			expect: false,
+		},
+		{
+			name:   "String same",
+			a:      String("a"),
+			b:      String("a"),
+			expect: true,
+		},
+		{
+			name:   "String different",
+			a:      String("a"),
+			b:      String("b"),
+			expect: false,
+		},
+		{
+			name:   "Uint16 same",
+			a:      Uint16(1),
+			b:      Uint16(1),
+			expect: true,
+		},
+		{
+			name:   "Uint16 different",
+			a:      Uint16(1),
+			b:      Uint16(0),
+			expect: false,
+		},
+		{
+			name:   "Uint32 same",
+			a:      Uint32(1),
+			b:      Uint32(1),
+			expect: true,
+		},
+		{
+			name:   "Uint32 different",
+			a:      Uint32(1),
+			b:      Uint32(0),
+			expect: false,
+		},
+		{
+			name:   "Uint64 same",
+			a:      Uint64(1),
+			b:      Uint64(1),
+			expect: true,
+		},
+		{
+			name:   "Uint64 different",
+			a:      Uint64(1),
+			b:      Uint64(0),
+			expect: false,
+		},
+		{
+			name:   "Uint128 same",
+			a:      (*Uint128)(big.NewInt(1)),
+			b:      (*Uint128)(big.NewInt(1)),
+			expect: true,
+		},
+		{
+			name:   "Uint128 different",
+			a:      (*Uint128)(big.NewInt(1)),
+			b:      (*Uint128)(big.NewInt(0)),
+			expect: false,
+		},
+		{
+			name:   "Int32 and Uint32 with same value are not equal",
+			a:      Int32(1),
+			b:      Uint32(1),
+			expect: false,
+		},
+		{
+			name:   "Complex Slice with same values",
+			a:      Slice{Int32(-1), Map{"a": String("blah")}, Uint16(0)},
+			b:      Slice{Int32(-1), Map{"a": String("blah")}, Uint16(0)},
+			expect: true,
+		},
+		{
+			name:   "Complex Slice with first being prefix of second",
+			a:      Slice{Int32(-1), Map{"a": String("blah")}, Uint16(0)},
+			b:      Slice{Int32(-1), Map{"a": String("blah")}, Uint16(0), Uint32(10)},
+			expect: false,
+		},
+		{
+			name:   "Same underlying Slice",
+			a:      sameSlice,
+			b:      sameSlice,
+			expect: true,
+		},
+		{
+			name: "Complex Map with same values",
+			a: Map{
+				"v1": Map{
+					"i1": Slice{String("fda"), Map{}},
+				},
+
+				"v2": Uint64(3212213),
+			},
+
+			b: Map{
+				"v1": Map{
+					"i1": Slice{String("fda"), Map{}},
+				},
+				"v2": Uint64(3212213),
+			},
+			expect: true,
+		},
+		{
+			name: "Complex Map with second having extra value",
+			a: Map{
+				"v1": Map{
+					"i1": Slice{String("fda"), Map{}},
+				},
+
+				"v2": Uint64(3212213),
+			},
+			b: Map{
+				"v1": Map{
+					"i1": Slice{String("fda"), Map{}},
+				},
+				"v2": Uint64(3212213),
+				"v3": Bool(false),
+			},
+			expect: false,
+		},
+		{
+			name:   "Same underlying Map",
+			a:      sameMap,
+			b:      sameMap,
+			expect: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(
+				t,
+				test.expect,
+				test.a.Equal(test.b),
+			)
+		})
+	}
+}
+
 // No pow or bit shifting for big int, apparently :-(
 // This is _not_ meant to be a comprehensive power function.
 func powBigInt(bi *big.Int, pow uint) *big.Int {

--- a/node.go
+++ b/node.go
@@ -3,7 +3,6 @@ package mmdbwriter
 import (
 	"fmt"
 	"net"
-	"reflect"
 
 	"github.com/maxmind/mmdbwriter/mmdbtype"
 )
@@ -85,7 +84,7 @@ func (r *record) insert(
 					iRec.dataMap.remove(r.value)
 					r.recordType = recordTypeEmpty
 					r.value = nil
-				} else if !reflect.DeepEqual(oldData, newData) {
+				} else if oldData == nil || !oldData.Equal(newData) {
 					iRec.dataMap.remove(r.value)
 					value, err := iRec.dataMap.store(newData)
 					if err != nil {


### PR DESCRIPTION
- Do not store data if it is equal to the current data
- Add checks that types implement interface
- Eliminate use of reflection for equality
- Compare map pointers to avoid iteration
- Add some basic Equal tests
