### PR TITLE
Merge nodes on insertion rather than when finalizing

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -433,7 +433,7 @@ func (t *Tree) Get(ip net.IP) (*net.IPNet, mmdbtype.DataType) {
 
 // finalize prepares the tree for writing. It is not threadsafe.
 func (t *Tree) finalize() {
-	_, t.nodeCount = t.root.finalize(0)
+	t.nodeCount = t.root.finalize(0)
 }
 
 // WriteTo writes the tree to the provided Writer.

--- a/tree_test.go
+++ b/tree_test.go
@@ -345,7 +345,7 @@ func TestTreeInsertAndGet(t *testing.T) {
 					expectedLookupValue: s2ip("string"),
 				},
 			},
-			expectedNodeCount: 352,
+			expectedNodeCount: 351,
 		},
 		{
 			name: "all types and pointers",
@@ -377,7 +377,7 @@ func TestTreeInsertAndGet(t *testing.T) {
 					expectedLookupValue: &allTypesLookupRecord,
 				},
 			},
-			expectedNodeCount: 369,
+			expectedNodeCount: 368,
 		},
 		{
 			name: "node pruning",
@@ -408,7 +408,7 @@ func TestTreeInsertAndGet(t *testing.T) {
 					}(),
 				},
 			},
-			expectedNodeCount: 367,
+			expectedNodeCount: 366,
 		},
 		{
 			name:       "insertion of range with multiple subnets",
@@ -464,7 +464,7 @@ func TestTreeInsertAndGet(t *testing.T) {
 					expectedLookupValue: s2ip("string"),
 				},
 			},
-			expectedNodeCount: 376,
+			expectedNodeCount: 375,
 		},
 	}
 


### PR DESCRIPTION
This can reduce the amount of work later insertions have to do as
they won't need to update extra duplicate data values.

The test differences are because there were two reserved networks
that could be merged, which we previously didn't check for.
