### PR TITLE
Fix control-byte computation at boundary sizes

### DIFF
--- a/mmdbtype/types.go
+++ b/mmdbtype/types.go
@@ -723,15 +723,15 @@ func writeCtrlByte(w writer, t DataType) (int64, error) {
 	switch {
 	case size < firstSize:
 		firstByte |= byte(size)
-	case size <= secondSize:
+	case size < secondSize:
 		firstByte |= 29
 		leftOver = size - firstSize
 		leftOverSize = 1
-	case size <= thirdSize:
+	case size < thirdSize:
 		firstByte |= 30
 		leftOver = size - secondSize
 		leftOverSize = 2
-	case size <= maxSize:
+	case size < maxSize:
 		firstByte |= 31
 		leftOver = size - thirdSize
 		leftOverSize = 3
@@ -739,7 +739,7 @@ func writeCtrlByte(w writer, t DataType) (int64, error) {
 		return 0, fmt.Errorf(
 			"cannot store %d bytes; max size is %d",
 			size,
-			maxSize,
+			maxSize-1,
 		)
 	}
 

--- a/tree_test.go
+++ b/tree_test.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 	"net"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -108,6 +109,36 @@ func TestTreeInsertAndGet(t *testing.T) {
 		"uint32":      uint64(0x10000000),
 		"uint64":      uint64(0x1000000000000000),
 		"utf8_string": "unicode! ☯ - ♫",
+	}
+
+	var stringsGetRecord = mmdbtype.Map{
+		// firstSize
+		"size28": mmdbtype.String(strings.Repeat("*", 28)),
+		"size29": mmdbtype.String(strings.Repeat("*", 29)),
+		"size30": mmdbtype.String(strings.Repeat("*", 30)),
+		// secondSize
+		"size284": mmdbtype.String(strings.Repeat("*", 284)),
+		"size285": mmdbtype.String(strings.Repeat("*", 285)),
+		"size286": mmdbtype.String(strings.Repeat("*", 286)),
+		// thirdSize
+		"size65820": mmdbtype.String(strings.Repeat("*", 65820)),
+		"size65821": mmdbtype.String(strings.Repeat("*", 65821)),
+		"size65822": mmdbtype.String(strings.Repeat("*", 65822)),
+		// maxSize
+		"maxSizeMinus1": mmdbtype.String(strings.Repeat("*", 16843036)),
+	}
+
+	var stringsLookupRecord any = map[string]any{
+		"size28":        strings.Repeat("*", 28),
+		"size29":        strings.Repeat("*", 29),
+		"size30":        strings.Repeat("*", 30),
+		"size284":       strings.Repeat("*", 284),
+		"size285":       strings.Repeat("*", 285),
+		"size286":       strings.Repeat("*", 286),
+		"size65820":     strings.Repeat("*", 65820),
+		"size65821":     strings.Repeat("*", 65821),
+		"size65822":     strings.Repeat("*", 65822),
+		"maxSizeMinus1": strings.Repeat("*", 16843036),
 	}
 
 	tests := []struct {
@@ -532,6 +563,26 @@ func TestTreeInsertAndGet(t *testing.T) {
 					expectedNetwork:     "1.1.1.6/32",
 					expectedGetValue:    mmdbtype.String("string"),
 					expectedLookupValue: s2ip("string"),
+				},
+			},
+			expectedNodeCount: 375,
+		},
+		{
+			name: "insertion of strings at boundary control byte size",
+			inserts: []testInsert{
+				{
+					network: "1.1.1.1/32",
+					start:   "1.1.1.1",
+					end:     "1.1.1.1",
+					value:   stringsGetRecord,
+				},
+			},
+			gets: []testGet{
+				{
+					ip:                  "1.1.1.1",
+					expectedNetwork:     "1.1.1.1/32",
+					expectedGetValue:    stringsGetRecord,
+					expectedLookupValue: &stringsLookupRecord,
 				},
 			},
 			expectedNodeCount: 375,


### PR DESCRIPTION
First off, thank you for this great Go library!

I've noticed that MMDB files generated by`mmdbwriter` become invalid when inserting strings with 285 or 65821 characters.

Looking in `mmdbwriter`'s codebase, it maps directly to the boundary sizes specified in [writeCtrlByte](https://github.com/maxmind/mmdbwriter/blob/main/mmdbtype/types.go#L721-L737). There seems to be an off-by-one error when determining the different control byte scenarios.

In the process, I found out that the boundary condition for the maximum supported size does not reflect the [MaxMind DB File Format Specification](https://maxmind.github.io/MaxMind-DB/#payload-size):

> the maximum payload size for a single field is 16,843,036 bytes.

### Technical details
`writeCtrlByte` writes the left-over byte using:
```
   byte((leftOver >> (8 * i)) & 0xFF)
```

This means that, after the `leftOver` value has been shifted, it should have a value in the [0,255] range so that the bitmask operation can work properly.

Currently, because the switch case determining `leftOver` is inclusive (<=) rather than inclusive (<), the shifted `leftOver` value can reach the value of 256, which is incorrectly written as a `0` control byte.

### Testing

I was able to verify that all boundary string sizes work as expected, from size 28 to 16843036.

I tried to test the `maxSize = 16843037` boundary condition with:
```
insertErrors: []testInsertError{
	{
		network:          "1.1.1.2/32",
		start:            "1.1.1.2",
		end:              "1.1.1.2",
		value:            mmdbtype.Map{
			"maxSize": mmdbtype.String(strings.Repeat("*", 16843037)),
		},
		expectedErrorMsg: "cannot store 16843037 bytes; max size is 16843036",
	},
},
```

but I get a non-trivial panic:
```
$ go test -timeout 30s -run ^TestTreeInsertAndGet$ github.com/maxmind/mmdbwriter
--- FAIL: TestTreeInsertAndGet (0.16s)
    --- FAIL: TestTreeInsertAndGet/Record_Size:_24 (0.14s)
        --- FAIL: TestTreeInsertAndGet/Record_Size:_24/insertion_of_strings_at_boundary_size (0.13s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x11a2be6]

goroutine 81 [running]:
testing.tRunner.func1.2({0x11d3f60, 0x13a4230})
        /usr/local/Cellar/go/1.20.6/libexec/src/testing/testing.go:1526 +0x24e
testing.tRunner.func1()
        /usr/local/Cellar/go/1.20.6/libexec/src/testing/testing.go:1529 +0x39f
panic({0x11d3f60, 0x13a4230})
        /usr/local/Cellar/go/1.20.6/libexec/src/runtime/panic.go:884 +0x213
github.com/maxmind/mmdbwriter.(*dataWriter).maybeWrite(0xc00341a0f0, 0x0)
        /Users/max/mmdbwriter/data_section.go:33 +0x26
github.com/maxmind/mmdbwriter.(*Tree).recordValue(0xc00002f000, {0x0?, 0x0?, 0x90?}, 0x11a3ae7?)
        /Users/max/mmdbwriter/tree.go:556 +0x65
github.com/maxmind/mmdbwriter.(*Tree).copyNode(0xc00002f000, {0xc00001c228, 0x6, 0xc00347bb10?}, 0xc0034bf000, 0x10dabd5?)
        /Users/max/mmdbwriter/tree.go:566 +0x65
github.com/maxmind/mmdbwriter.(*Tree).writeNode(0xc0034bf040?, {0x12674e0, 0xc0034bf040}, 0xc0034bf000, 0xc0034bef80?, {0xc00001c228, 0x6, 0x6})
        /Users/max/mmdbwriter/tree.go:516 +0x7a
github.com/maxmind/mmdbwriter.(*Tree).writeNode(0xc0034bf040?, {0x12674e0, 0xc0034bf040}, 0xc0034bef80, 0xc0034bef40?, {0xc00001c228, 0x6, 0x6})
```