### PR TITLE
added additional metadata info about an mmdb file

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -104,8 +104,10 @@ type Tree struct {
 	root                    *node
 	treeDepth               int
 	// This is set when the tree is finalized
-	nodeCount       int
-	inserterFuncGen inserter.FuncGenerator
+	nodeCount              int
+	treeSize               uint64
+	dataSectionStartOffset uint64
+	inserterFuncGen        inserter.FuncGenerator
 }
 
 // New creates a new Tree.
@@ -451,6 +453,8 @@ func (t *Tree) Get(ip net.IP) (*net.IPNet, mmdbtype.DataType) {
 // finalize prepares the tree for writing. It is not threadsafe.
 func (t *Tree) finalize() {
 	t.nodeCount = t.root.finalize(0)
+	t.treeSize = t.CalculateTreeSize()
+	t.dataSectionStartOffset = t.CalculateDataSectionStartOffset()
 }
 
 // WriteTo writes the tree to the provided Writer.
@@ -656,6 +660,8 @@ func (t *Tree) writeMetadata(dw *dataWriter) (int64, error) {
 		"languages":                   languages,
 		"node_count":                  mmdbtype.Uint32(t.nodeCount),
 		"record_size":                 mmdbtype.Uint16(t.recordSize),
+		"tree_size":                   mmdbtype.Uint64(t.treeSize),
+		"data_section_start_offset":   mmdbtype.Uint64(t.dataSectionStartOffset),
 	}
 	return metadata.WriteTo(dw)
 }

--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,11 @@
+package mmdbwriter
+
+// Calculates the search tree size in bytes as listed in the mmdb file specification
+func (t *Tree) CalculateTreeSize() uint64 {
+	return ((uint64(t.recordSize) * 2) / 8) * uint64(t.nodeCount)
+}
+
+// Calculates the data section start offset as listed in the mmdb file specification
+func (t *Tree) CalculateDataSectionStartOffset() uint64 {
+	return t.treeSize + 16
+}


### PR DESCRIPTION
Introduces slight enhancements to the `mmdbwriter` library by writing some valuable low-level info about the file in metadata section that can be used for external analysis or derive critical information of an `mmdb` file.