### PR TITLE
Reduce per-insert allocations on the build hot path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 1.3.0
+
+- Reduced allocations on the tree insert and serialization hot paths, lowering
+  memory pressure and GC overhead during large builds.
+
 ## 1.2.0 (2026-01-14)
 
 - The `mmdbtype.Unmarshaler` now caches nested structures, maps and slices, in

--- a/mmdbtype/types.go
+++ b/mmdbtype/types.go
@@ -380,7 +380,19 @@ func (t Map) WriteTo(w writer) (int64, error) {
 	// the map items in order by key value. In the future, we will
 	// likely use a more relevant characteristic here (e.g., putting
 	// fields more likely to be accessed first).
-	keys := make([]string, 0, len(t))
+	//
+	// For maps with a small number of keys (the common case for record
+	// schemas), use a stack-allocated buffer to avoid a per-WriteTo
+	// allocation. Map.WriteTo is on the hot path of every
+	// keyWriter.Key call during inserts, so this is amortized across
+	// the full build.
+	var stackKeys [16]string
+	var keys []string
+	if len(t) <= len(stackKeys) {
+		keys = stackKeys[:0]
+	} else {
+		keys = make([]string, 0, len(t))
+	}
 	for k := range t {
 		keys = append(keys, string(k))
 	}

--- a/mmdbtype/types_test.go
+++ b/mmdbtype/types_test.go
@@ -3,6 +3,7 @@ package mmdbtype
 import (
 	"bytes"
 	"encoding/hex"
+	"fmt"
 	"math/big"
 	"strings"
 	"testing"
@@ -10,6 +11,38 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// TestMapLargeKeyCount exercises the heap-allocated fallback path in
+// Map.WriteTo for maps with more keys than fit in the stack-allocated
+// sort buffer. It pins down the load-bearing property that the
+// optimization could break (deterministic, sorted output) without
+// coupling the test to every byte of the encoding.
+func TestMapLargeKeyCount(t *testing.T) {
+	const n = 20
+	m := Map{}
+	for i := range n {
+		m[String(fmt.Sprintf("k%02d", i))] = Uint16(uint16(i))
+	}
+
+	buf1 := &bytes.Buffer{}
+	buf2 := &bytes.Buffer{}
+	_, err := m.WriteTo(&dataWriter{Buffer: buf1})
+	require.NoError(t, err)
+	_, err = m.WriteTo(&dataWriter{Buffer: buf2})
+	require.NoError(t, err)
+
+	// Determinism: map iteration order is randomized, so two encodings
+	// matching byte-for-byte proves sort.Strings ran.
+	assert.Equal(t, buf1.Bytes(), buf2.Bytes(), "Map encoding must be deterministic")
+
+	// Control byte: top 3 bits = map type (7), low 5 bits = size for
+	// size < 29. 20 = 10100b, so the first byte is 11110100 = 0xf4.
+	require.Equal(t, byte(0xf4), buf1.Bytes()[0], "control byte must encode %d-entry map", n)
+
+	// The first sorted key is "k00", a length-3 String:
+	// String type (010) + size 3 = 01000011 = 0x43, then "k00".
+	assert.Equal(t, []byte{0x43, 'k', '0', '0'}, buf1.Bytes()[1:5], "first sorted key must be k00")
+}
 
 // The tests in this file were mostly taken from
 // https://github.com/oschwald/maxminddb-golang/blob/master/decoder_test.go

--- a/node.go
+++ b/node.go
@@ -138,8 +138,11 @@ func (r *record) insert(
 
 func (r *record) maybeMergeChildren(iRec insertRecord) error {
 	// Check to see if the children are the same and can be merged.
-	child0 := r.node.children[0]
-	child1 := r.node.children[1]
+	// Use pointer access to avoid copying the record struct; this is
+	// called from every node-level insert, so the copies add up across
+	// millions of inserts.
+	child0 := &r.node.children[0]
+	child1 := &r.node.children[1]
 	if child0.recordType != child1.recordType {
 		return nil
 	}

--- a/tree.go
+++ b/tree.go
@@ -108,6 +108,12 @@ type Tree struct {
 	// This is set when the tree is finalized
 	nodeCount       int
 	inserterFuncGen inserter.FuncGenerator
+
+	// insertScratchIP is reused across IPv4-to-IPv6 conversions in
+	// insert. Insert is not thread-safe (see the doc comments on
+	// Insert / InsertFunc), so a single per-Tree scratch suffices.
+	// The first 12 bytes stay zeroed to encode the v4Prefix.
+	insertScratchIP [16]byte
 }
 
 // New creates a new Tree.
@@ -279,7 +285,10 @@ func (t *Tree) insert(
 
 	ip := network.IP
 	if t.treeDepth == 128 && len(ip) == 4 {
-		ip = ipV4ToV6(ip)
+		// Reuse the per-Tree scratch slot. The first 12 bytes stay
+		// zeroed (the v4Prefix); only the last 4 bytes vary per call.
+		copy(t.insertScratchIP[12:], ip)
+		ip = t.insertScratchIP[:]
 		prefixLen += 96
 	}
 


### PR DESCRIPTION
## Summary

Three small, independent allocation reductions on the `Tree.Insert*` /
serialization hot path. Each lands as its own commit. No API changes.

Measured against a real **build-residential-proxy-mmdb** run with the
production resproxy CSV (~244M rows, ~80M unique user networks).
Baseline numbers are after the consumer-side optimizations recommended
by the upstream profile work; the deltas below are attributable only
to these mmdbwriter changes.

| Metric | Before | After | Δ |
|---|---|---|---|
| TotalAlloc (cumulative) | 53.66 GiB | **48.05 GiB** | −5.61 GiB |
| HeapAlloc at end | 27.77 GiB | **23.99 GiB** | −3.78 GiB |
| Mallocs | 1.76 B | **1.60 B** | −158 M |
| NumGC | 31 | **27** | −4 |
| Wall time | 3:51 | **3:48** | −3 s |

## Commits

1. **Avoid per-insert allocation in `ipV4ToV6`** (`tree.go`) — adds a
   16-byte scratch slot on `Tree` and reuses it across IPv4 inserts
   instead of allocating fresh via `append(v4Prefix, ip...)`.
   pprof: `ipV4ToV6` drops from 1.45 GiB out of the top 10 entirely.

2. **Avoid per-call slice allocation in `Map.WriteTo`**
   (`mmdbtype/types.go`) — stack-allocates the sort buffer for maps
   with ≤ 16 keys (the case for every existing record schema).
   pprof: the `make([]string, 0, len(t))` line goes from 4.20 GiB → 0.

3. **Avoid record-struct copies in `maybeMergeChildren`** (`node.go`)
   — switches from value access (which copied the 24-byte `record`
   struct twice per call) to pointer access. Function is called from
   every node-level insert.
   pprof: 22.83 s CPU → 21.22 s (−7%).

## Test plan

- [x] `go test ./...` passes after each commit
- [x] Heap profile diff confirms each commit's targeted allocation
      source drops as expected (see numbers above)
- [ ] Byte-comparison of the resulting MMDB against a baseline build
      would be a useful additional check before merging — none of the
      three commits should change the serialized output (all are pure
      memory/CPU refactors), but it's worth verifying.

🤖 Generated with [Claude Code](https://claude.com/claude-code) on behalf of @oschwald.