### PR TITLE
Validate and update links (STF-557)

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,0 +1,32 @@
+name: Links
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 13 * * 1" # weekly, to catch external link rot without a commit
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  linkChecker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup mise
+        uses: jdx/mise-action@6d1e696aa24c1aa1bcc1adea0212707c71ab78a8 # v3.6.1
+        with:
+          install: false
+
+      # Install only lychee (not the repo's full toolchain) and run the check.
+      - name: Check links
+        env:
+          MISE_AUTO_INSTALL: "false"
+        run: |
+          mise install lychee
+          mise run check-links

--- a/.github/workflows/modver.yml
+++ b/.github/workflows/modver.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: bobg/modver@5b8d0533390faf5542fd9ab530ca3075c32a7201 # 2.14.1
+      - uses: bobg/modver@5b8d0533390faf5542fd9ab530ca3075c32a7201 # v2.14.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           pull_request_url: https://github.com/${{ github.repository }}/pull/${{ github.event.number }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.sw?
+.lycheecache

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ subject to change.
 
 See the `examples` folder for examples of how to use this library or our blog
 post,
-[Enriching MMDB files with your own data using Go](https://blog.maxmind.com/2020/09/01/enriching-mmdb-files-with-your-own-data-using-go/).
+[Enriching MMDB files with your own data using Go](https://blog.maxmind.com/enriching-mmdb-files-with-your-own-data-using-go/).
 
 ## Copyright and License
 

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,57 @@
+# Lychee link checker configuration
+# https://lychee.cli.rs/#/usage/config
+#
+# Run locally with:
+#   lychee './**/*.md' './**/*.go'
+
+# Include URL fragments in checks
+include_fragments = true
+
+# Don't allow any redirects, so links that have moved are surfaced and can be
+# updated to their canonical destination.
+max_redirects = 0
+
+# Accept these HTTP status codes
+# 100-103: Informational responses
+# 200-299: Success responses
+# 403: Forbidden (some sites use this for rate limiting)
+# 429: Too Many Requests
+# 500-599: Server errors (temporary issues shouldn't fail CI)
+# 999: LinkedIn's custom status code
+accept = ["100..=103", "200..=299", "403", "429", "500..=599", "999"]
+
+# Exclude URL patterns from checking (treated as regular expressions)
+exclude = [
+    # GitHub blob URLs with line-number fragments (not parseable as page anchors)
+    '^https://github\.com/[^/]+/[^/]+/blob/[0-9a-fA-F]+/.+#L\d+$',
+    # Live / auth-gated MaxMind endpoints: appear as code string literals or
+    # require login, so they can't be verified by an anonymous request.
+    '^https://geoip\.maxmind\.com',
+    '^https://geolite\.info',
+    '^https://minfraud\.maxmind\.com',
+    '^https://sandbox\.maxmind\.com',
+    '^https://updates\.maxmind\.com',
+    '^https://www\.maxmind\.com/en/accounts/',
+    '^https://www\.maxmind\.com/en/account/login',
+    # Local / placeholder URLs (e.g. the proxy example in docstrings)
+    '^file://',
+    '^https?://example\.(com|org|net)',
+    '^http://localhost',
+    '127\.0\.0\.1',
+]
+
+# Exclude file paths from getting checked (regular expressions, matched against
+# the path relative to the working directory). Patterns are segment-anchored
+# with (^|/) so short names like "build" don't match unintended paths.
+exclude_path = [
+    '(^|/)vendor/',
+    # Changelog: historical entries are preserved as-is, not rewritten
+    '(^|/)CHANGELOG\.md$',
+]
+
+# Cache results for 1 day to speed up repeated checks
+cache = true
+max_cache_age = "1d"
+
+# Skip missing input files instead of erroring
+skip_missing = true

--- a/mise.lock
+++ b/mise.lock
@@ -110,6 +110,34 @@ url = "https://dl.google.com/go/go1.26.1.darwin-amd64.tar.gz"
 checksum = "sha256:9b68112c913f45b7aebbf13c036721264bbba7e03a642f8f7490c561eebd1ecc"
 url = "https://dl.google.com/go/go1.26.1.windows-amd64.zip"
 
+[[tools.lychee]]
+version = "0.23.0"
+backend = "aqua:lycheeverse/lychee"
+
+[tools.lychee."platforms.linux-arm64"]
+checksum = "sha256:97eb93b02a7d78a752fc33e5b0983439ccaadbf3db952b68a0a4401acd92e6e0"
+url = "https://github.com/lycheeverse/lychee/releases/download/lychee-v0.23.0/lychee-aarch64-unknown-linux-gnu.tar.gz"
+
+[tools.lychee."platforms.linux-arm64-musl"]
+checksum = "sha256:97eb93b02a7d78a752fc33e5b0983439ccaadbf3db952b68a0a4401acd92e6e0"
+url = "https://github.com/lycheeverse/lychee/releases/download/lychee-v0.23.0/lychee-aarch64-unknown-linux-gnu.tar.gz"
+
+[tools.lychee."platforms.linux-x64"]
+checksum = "sha256:5538440d2c69a45a0a09983271e5dee0c2fe7137d8035d25b2632e10a66a090a"
+url = "https://github.com/lycheeverse/lychee/releases/download/lychee-v0.23.0/lychee-x86_64-unknown-linux-musl.tar.gz"
+
+[tools.lychee."platforms.linux-x64-musl"]
+checksum = "sha256:5538440d2c69a45a0a09983271e5dee0c2fe7137d8035d25b2632e10a66a090a"
+url = "https://github.com/lycheeverse/lychee/releases/download/lychee-v0.23.0/lychee-x86_64-unknown-linux-musl.tar.gz"
+
+[tools.lychee."platforms.macos-arm64"]
+checksum = "sha256:4c8034900e11083b68ac6f6582c377ff1f704e268991999e09d717973e493e7f"
+url = "https://github.com/lycheeverse/lychee/releases/download/lychee-v0.23.0/lychee-arm64-macos.dmg"
+
+[tools.lychee."platforms.windows-x64"]
+checksum = "sha256:0fda7ff0a60c0250939fc25361c2d4e6e7853c31c996733fdd5a1dd760bcb824"
+url = "https://github.com/lycheeverse/lychee/releases/download/lychee-v0.23.0/lychee-x86_64-windows.exe"
+
 [[tools.node]]
 version = "25.8.0"
 backend = "core:node"

--- a/mise.toml
+++ b/mise.toml
@@ -11,6 +11,7 @@ go = "latest"
 "github:houseabsolute/precious" = "latest"
 node = "latest"
 "npm:prettier" = "latest"
+lychee = "latest"
 
 [hooks]
 enter = "mise install --quiet"
@@ -18,3 +19,7 @@ enter = "mise install --quiet"
 [[watch_files]]
 patterns = ["mise.toml", "mise.lock"]
 run = "mise install --quiet"
+
+[tasks.check-links]
+description = "Check links with lychee"
+run = "lychee --no-progress './**/*.md' './**/*.go'"

--- a/mmdbtype/types_test.go
+++ b/mmdbtype/types_test.go
@@ -45,7 +45,7 @@ func TestMapLargeKeyCount(t *testing.T) {
 }
 
 // The tests in this file were mostly taken from
-// https://github.com/oschwald/maxminddb-golang/blob/master/decoder_test.go
+// https://github.com/oschwald/maxminddb-golang/blob/main/internal/decoder/decoder_test.go
 
 func TestBool(t *testing.T) {
 	bools := map[string]DataType{

--- a/reserved.go
+++ b/reserved.go
@@ -33,7 +33,7 @@ var reservedNetworksIPv4 = []string{
 	"198.51.100.0/24",
 	"203.0.113.0/24",
 	// The above IANA page doesn't list 224.0.0.0/4, but at least some parts
-	// are listed in https://tools.ietf.org/html/rfc5771
+	// are listed in https://datatracker.ietf.org/doc/html/rfc5771
 	"224.0.0.0/4",
 	"240.0.0.0/4",
 	// 255.255.255.255/32 gets brought in by 240.0.0.0/4.


### PR DESCRIPTION
Adds a lychee link checker (config + CI workflow) and fixes stale/redirecting links across the repo.

## Tooling
- `lychee.toml`: `max_redirects = 0` so moved links surface; accepts 5xx as transient; excludes `vendor/` and `CHANGELOG.md`.
- `.github/workflows/links.yml`: runs on push, pull request, weekly cron, and manual dispatch, via `jdx/mise-action`.
- lychee pinned to 0.23.0 in `mise.toml` (with `mise.lock` updated) and run via a `check-links` mise task.
- `.lycheecache` added to `.gitignore`.

## Link fixes (old -> new)
- `mmdbtype/types_test.go`: `github.com/oschwald/maxminddb-golang/blob/master/decoder_test.go` (404) -> `.../blob/main/internal/decoder/decoder_test.go` (file moved)
- `README.md`: `blog.maxmind.com/2020/09/01/enriching-mmdb-files-with-your-own-data-using-go/` -> `blog.maxmind.com/enriching-mmdb-files-with-your-own-data-using-go/`
- `reserved.go`: `tools.ietf.org/html/rfc5771` -> `datatracker.ietf.org/doc/html/rfc5771`

Final lychee run: 10 OK, 0 errors, 4 excluded. `precious lint` passes.

Part of STF-557.

🤖 Generated with [Claude Code](https://claude.com/claude-code)