### PR TITLE
STF-1412: Add insertion metadata to inserters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,26 +12,35 @@
   trees, IPv4-mapped prefixes at `/96` or longer are treated as IPv4 prefixes,
   IPv4-mapped prefixes shorter than `/96` are rejected, and aliased or reserved
   network errors report masked `netip.Prefix` values.
-- Changed the inserter API so inserters receive both the existing value and the
-  new value directly. This removes per-insertion closure generation from merge
-  insertion paths. `inserter.ReplaceWith`, `inserter.TopLevelMergeWith`, and
-  `inserter.DeepMergeWith` are replaced by `inserter.Replace`,
-  `inserter.TopLevelMerge`, and `inserter.DeepMerge`. `inserter.FuncGenerator`
-  was removed, `Options.Inserter` now accepts an `inserter.Func`, and
-  `Tree.InsertFunc` and `Tree.InsertRangeFunc` now take the new value and a
-  function. These functions are evaluated separately for every covered record,
-  as in v1. Added `Tree.InsertPureFunc` and `Tree.InsertRangePureFunc` for
-  functions whose result and error depend only on their arguments. These methods
-  may memoize repeated argument pairs within an insertion;
-  `Tree.InsertRangePureFunc` shares the memo across the entire range. A nil
-  function passed to `Tree.InsertFunc`, `Tree.InsertRangeFunc`,
+- Changed the inserter API so inserters receive the existing value, the new
+  value, and an `inserter.Metadata` describing the insertion and existing tree
+  record. This removes per-insertion closure generation from merge insertion
+  paths and lets callers compare the inserted network with the current record
+  extent without a separate lookup. `inserter.ReplaceWith`,
+  `inserter.TopLevelMergeWith`, and `inserter.DeepMergeWith` are replaced by
+  `inserter.Replace`, `inserter.TopLevelMerge`, and `inserter.DeepMerge`.
+  `inserter.FuncGenerator` was removed, `Options.Inserter` now accepts an
+  `inserter.Func`, and `Tree.InsertFunc` and `Tree.InsertRangeFunc` now take the
+  new value and a function. These functions are evaluated separately for every
+  covered record, as in v1. Added `Tree.InsertPureFunc` and
+  `Tree.InsertRangePureFunc` for functions whose result and error depend only on
+  their arguments. These methods may memoize repeated argument pairs within an
+  insertion; `Tree.InsertRangePureFunc` shares the memo across the entire range.
+  A nil function passed to `Tree.InsertFunc`, `Tree.InsertRangeFunc`,
   `Tree.InsertPureFunc`, or `Tree.InsertRangePureFunc` now returns an error;
   `Options.Inserter` may still be nil, which is equivalent to
-  `inserter.Replace`. Non-nil results become tree-owned and must not be modified
-  after the function returns. As in v1, a function that fails partway through
-  the covered records leaves the records already visited holding their new
-  values; interning now validates values per record, so more error kinds can
-  fire mid-walk.
+  `inserter.Replace`. Range insertions report each decomposed subnet, and Load
+  reports each normalized source network. Metadata reflects the record as shaped
+  by prior splits and merges, not the network that established its value;
+  provenance-dependent policies must keep that state in their values.
+  `Metadata.ExistingNetwork()` follows the inserted network's address family,
+  and the pure methods supply zero metadata to preserve their value-keyed memo.
+  Non-nil results become tree-owned and must not be modified after the function
+  returns. As in v1, a function that fails partway through the covered records
+  leaves the records already visited holding their new values; installed equal
+  values may coalesce during error unwinding, while a failure before any result
+  leaves the tree logically unchanged. Interning now validates values per
+  record, so more error kinds can fire mid-walk.
 - Reduced allocations on the tree insert and serialization hot paths, lowering
   memory pressure and GC overhead during large builds.
 - Reworked value storage to intern every value node once in a content-addressed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,14 +33,17 @@
   reports each normalized source network. Metadata reflects the record as shaped
   by prior splits and merges, not the network that established its value;
   provenance-dependent policies must keep that state in their values.
-  `Metadata.ExistingNetwork()` follows the inserted network's address family,
-  and the pure methods supply zero metadata to preserve their value-keyed memo.
-  Non-nil results become tree-owned and must not be modified after the function
-  returns. As in v1, a function that fails partway through the covered records
-  leaves the records already visited holding their new values; installed equal
-  values may coalesce during error unwinding, while a failure before any result
-  leaves the tree logically unchanged. Interning now validates values per
-  record, so more error kinds can fire mid-walk.
+  `Metadata.ExistingNetwork()` follows the inserted network's address family.
+  For an IPv4 insert into an IPv6 tree, a record above the IPv4 subtree remains
+  in IPv6 form. The method returns the zero prefix when the existing record is
+  more specific than the inserted network. The pure methods supply zero metadata
+  to preserve their value-keyed memo. Non-nil results become tree-owned and must
+  not be modified after the function returns. As in v1, a function that returns
+  an error partway through the covered records leaves the records already
+  visited holding their new values. Installed equal values may coalesce during
+  error unwinding, while an error before any result leaves the tree logically
+  unchanged. Interning now validates values per record, so more error kinds can
+  fire mid-walk.
 - Reduced allocations on the tree insert and serialization hot paths, lowering
   memory pressure and GC overhead during large builds.
 - Reworked value storage to intern every value node once in a content-addressed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,8 +31,9 @@
     subnet.
   - `Metadata.ExistingNetwork()` follows the inserted network's address family.
     For an IPv4 insert into an IPv6 tree, a record above the IPv4 subtree
-    remains in IPv6 form. The method returns the zero prefix when the existing
-    record is more specific than the inserted network.
+    remains in IPv6 form. Every covered record reports its own extent, including
+    records more specific than the inserted network, so an insert covering
+    several records tells the callback which one it is resolving.
   - `inserter.Replace`, `inserter.TopLevelMerge`, and `inserter.DeepMerge`
     replace `inserter.ReplaceWith`, `inserter.TopLevelMergeWith`, and
     `inserter.DeepMergeWith`. `inserter.FuncGenerator` was removed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,38 +12,40 @@
   trees, IPv4-mapped prefixes at `/96` or longer are treated as IPv4 prefixes,
   IPv4-mapped prefixes shorter than `/96` are rejected, and aliased or reserved
   network errors report masked `netip.Prefix` values.
-- Changed the inserter API so inserters receive the existing value, the new
-  value, and an `inserter.Metadata` describing the insertion and existing tree
-  record. This removes per-insertion closure generation from merge insertion
-  paths and lets callers compare the inserted network with the current record
-  extent without a separate lookup. `inserter.ReplaceWith`,
-  `inserter.TopLevelMergeWith`, and `inserter.DeepMergeWith` are replaced by
-  `inserter.Replace`, `inserter.TopLevelMerge`, and `inserter.DeepMerge`.
-  `inserter.FuncGenerator` was removed, `Options.Inserter` now accepts an
-  `inserter.Func`, and `Tree.InsertFunc` and `Tree.InsertRangeFunc` now take the
-  new value and a function. These functions are evaluated separately for every
-  covered record, as in v1. Added `Tree.InsertPureFunc` and
-  `Tree.InsertRangePureFunc` for functions whose result and error depend only on
-  their arguments. These methods may memoize repeated argument pairs within an
-  insertion; `Tree.InsertRangePureFunc` shares the memo across the entire range.
-  A nil function passed to `Tree.InsertFunc`, `Tree.InsertRangeFunc`,
-  `Tree.InsertPureFunc`, or `Tree.InsertRangePureFunc` now returns an error;
-  `Options.Inserter` may still be nil, which is equivalent to
-  `inserter.Replace`. Range insertions report each decomposed subnet, and Load
-  reports each normalized source network. Metadata reflects the record as shaped
-  by prior splits and merges, not the network that established its value;
-  provenance-dependent policies must keep that state in their values.
-  `Metadata.ExistingNetwork()` follows the inserted network's address family.
-  For an IPv4 insert into an IPv6 tree, a record above the IPv4 subtree remains
-  in IPv6 form. The method returns the zero prefix when the existing record is
-  more specific than the inserted network. The pure methods supply zero metadata
-  to preserve their value-keyed memo. Non-nil results become tree-owned and must
-  not be modified after the function returns. As in v1, a function that returns
-  an error partway through the covered records leaves the records already
-  visited holding their new values. Installed equal values may coalesce during
-  error unwinding, while an error before any result leaves the tree logically
-  unchanged. Interning now validates values per record, so more error kinds can
-  fire mid-walk.
+- Split inserter callbacks into `inserter.PureFunc` and `inserter.Func`.
+  - `PureFunc` receives the existing and new values. `Options.Inserter`, the
+    default `Tree.Insert` and `Tree.InsertRange` paths, `Tree.InsertPureFunc`,
+    `Tree.InsertRangePureFunc`, and every function in the `inserter` package use
+    it. Its result and error must depend only on those values, so an insertion
+    may memoize repeated argument pairs. `Tree.InsertRangePureFunc` and
+    `Tree.InsertRange` share the memo across the entire range.
+  - `Func` also receives an `inserter.Metadata` describing the insertion and the
+    existing tree record. Only `Tree.InsertFunc` and `Tree.InsertRangeFunc`
+    accept it, and they call it separately for every covered record. A caller
+    can compare the inserted network with the current record without a separate
+    lookup, and the common and load paths stay unable to depend on tree
+    metadata.
+  - Metadata reports the record as prior splits and merges left it, not the
+    network that established its value. A policy that depends on that provenance
+    must keep the state in its values. Range metadata reports each decomposed
+    subnet.
+  - `Metadata.ExistingNetwork()` follows the inserted network's address family.
+    For an IPv4 insert into an IPv6 tree, a record above the IPv4 subtree
+    remains in IPv6 form. The method returns the zero prefix when the existing
+    record is more specific than the inserted network.
+  - `inserter.Replace`, `inserter.TopLevelMerge`, and `inserter.DeepMerge`
+    replace `inserter.ReplaceWith`, `inserter.TopLevelMergeWith`, and
+    `inserter.DeepMergeWith`. `inserter.FuncGenerator` was removed.
+  - A nil function passed to an explicit insert method returns an error.
+    `Options.Inserter` may still be nil, which is equivalent to
+    `inserter.Replace`.
+  - Non-nil callback results become tree-owned and must not be modified after
+    the function returns. As in v1, a callback that returns an error partway
+    through the covered records leaves the records already visited holding their
+    new values. Installed equal values may coalesce during error unwinding,
+    while an error before any result leaves the tree logically unchanged.
+    Interning now validates values per record, so more error kinds can fire
+    mid-walk.
 - Reduced allocations on the tree insert and serialization hot paths, lowering
   memory pressure and GC overhead during large builds.
 - Reworked value storage to intern every value node once in a content-addressed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,17 @@
     default `Tree.Insert` and `Tree.InsertRange` paths, `Tree.InsertPureFunc`,
     `Tree.InsertRangePureFunc`, and every function in the `inserter` package use
     it. Its result and error must depend only on those values, so an insertion
-    may memoize repeated argument pairs. `Tree.InsertRangePureFunc` and
-    `Tree.InsertRange` share the memo across the entire range.
+    may memoize repeated argument pairs. `Tree.InsertRangePureFunc` shares the
+    memo across the entire range, as does `Tree.InsertRange` when
+    `Options.Inserter` is set. With the default nil inserter, `Tree.InsertRange`
+    takes the direct-value path and there is no memo.
+  - **This is the one change that does not fail to compile.** `Options.Inserter`
+    keeps the two-argument shape it had in v1, so an existing inserter still
+    compiles, but it is now memoized: it runs once per distinct existing value
+    instead of once per covered record. An inserter that counts calls, allocates
+    identifiers, or reads mutable state changes behavior with no compile error.
+    Pass such a function to `Tree.InsertFunc` or `Tree.InsertRangeFunc` instead,
+    which never memoize.
   - `Func` also receives an `inserter.Metadata` describing the insertion and the
     existing tree record: `InsertedNetwork`, `ExistingDepth`, `ExistingAddr`,
     `TreeDepth`, and the derived `InsertedDepth()` and `ExistingNetwork()`. Only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,10 +43,10 @@
   - Non-nil callback results become tree-owned and must not be modified after
     the function returns. As in v1, a callback that returns an error partway
     through the covered records leaves the records already visited holding their
-    new values. Installed equal values may coalesce during error unwinding,
-    while an error before any result leaves the tree logically unchanged.
-    Interning now validates values per record, so more error kinds can fire
-    mid-walk.
+    new values. Installed equal values, and records that become equally empty,
+    may coalesce during error unwinding, while an error before any result leaves
+    the tree logically unchanged. Interning now validates values per record, so
+    more error kinds can fire mid-walk.
 - Reduced allocations on the tree insert and serialization hot paths, lowering
   memory pressure and GC overhead during large builds.
 - Reworked value storage to intern every value node once in a content-addressed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,12 @@
     may memoize repeated argument pairs. `Tree.InsertRangePureFunc` and
     `Tree.InsertRange` share the memo across the entire range.
   - `Func` also receives an `inserter.Metadata` describing the insertion and the
-    existing tree record. Only `Tree.InsertFunc` and `Tree.InsertRangeFunc`
-    accept it, and they call it separately for every covered record. A caller
-    can compare the inserted network with the current record without a separate
-    lookup, and the common and load paths stay unable to depend on tree
-    metadata.
+    existing tree record: `InsertedNetwork`, `ExistingDepth`, `ExistingAddr`,
+    `TreeDepth`, and the derived `InsertedDepth()` and `ExistingNetwork()`. Only
+    `Tree.InsertFunc` and `Tree.InsertRangeFunc` accept it, and they call it
+    separately for every covered record. A caller can compare the inserted
+    network with the current record without a separate lookup, and the common
+    and load paths stay unable to depend on tree metadata.
   - Metadata reports the record as prior splits and merges left it, not the
     network that established its value. A policy that depends on that provenance
     must keep the state in its values. Range metadata reports each decomposed
@@ -39,8 +40,14 @@
     it is resolving.
   - `inserter.Replace`, `inserter.TopLevelMerge`, and `inserter.DeepMerge`
     replace `inserter.ReplaceWith`, `inserter.TopLevelMergeWith`, and
-    `inserter.DeepMergeWith`. `inserter.FuncGenerator` was removed.
-  - A nil function passed to an explicit insert method returns an error.
+    `inserter.DeepMergeWith`.
+  - `inserter.FuncGenerator` was removed. It was the network-aware inserter API,
+    and `inserter.Func` replaces it: pass one to `Tree.InsertFunc` or
+    `Tree.InsertRangeFunc` and read `Metadata.InsertedNetwork` in place of the
+    network the generator closed over, or `Metadata.ExistingNetwork()` for the
+    record being replaced.
+  - A nil function passed to `Tree.InsertFunc`, `Tree.InsertRangeFunc`,
+    `Tree.InsertPureFunc`, or `Tree.InsertRangePureFunc` returns an error.
     `Options.Inserter` may still be nil, which is equivalent to
     `inserter.Replace`.
   - Non-nil callback results become tree-owned and must not be modified after

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,9 +31,12 @@
     subnet.
   - `Metadata.ExistingNetwork()` follows the inserted network's address family.
     For an IPv4 insert into an IPv6 tree, a record above the IPv4 subtree
-    remains in IPv6 form. Every covered record reports its own extent, including
-    records more specific than the inserted network, so an insert covering
-    several records tells the callback which one it is resolving.
+    remains in IPv6 form. Only `Options.DisableIPv4Aliasing` reaches such a
+    record: aliasing splits the path down to depth 96, so an IPv4 insert into a
+    default IPv6 tree resolves at depth 97 or deeper. Every covered record
+    reports its own extent, including records more specific than the inserted
+    network, so an insert covering several records tells the callback which one
+    it is resolving.
   - `inserter.Replace`, `inserter.TopLevelMerge`, and `inserter.DeepMerge`
     replace `inserter.ReplaceWith`, `inserter.TopLevelMergeWith`, and
     `inserter.DeepMergeWith`. `inserter.FuncGenerator` was removed.

--- a/audit_test.go
+++ b/audit_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/maxmind/mmdbwriter/v2/inserter"
 	"github.com/maxmind/mmdbwriter/v2/mmdbtype"
 )
 
@@ -131,7 +132,7 @@ func TestFailedInsertsPassTheAudit(t *testing.T) {
 				return tree.InsertPureFunc(
 					netip.MustParsePrefix("1.0.0.0/24"),
 					mmdbtype.String("new"),
-					func(_, newValue mmdbtype.DataType) (mmdbtype.DataType, error) {
+					func(_, newValue mmdbtype.DataType, _ inserter.Metadata) (mmdbtype.DataType, error) {
 						calls++
 						if calls == 2 {
 							return nil, errors.New("inserter failure")
@@ -149,7 +150,7 @@ func TestFailedInsertsPassTheAudit(t *testing.T) {
 				return tree.InsertFunc(
 					netip.MustParsePrefix("1.0.0.0/24"),
 					mmdbtype.String("new"),
-					func(_, _ mmdbtype.DataType) (mmdbtype.DataType, error) {
+					func(_, _ mmdbtype.DataType, _ inserter.Metadata) (mmdbtype.DataType, error) {
 						return mmdbtype.Map{"p": mmdbtype.Pointer(7)}, nil
 					},
 				)

--- a/audit_test.go
+++ b/audit_test.go
@@ -143,6 +143,46 @@ func TestFailedInsertsPassTheAudit(t *testing.T) {
 			},
 		},
 		{
+			// The callback fails on the first of two in-network children, so
+			// the walk unwinds before the sibling is visited.
+			name: "inserter error on the first covered record",
+			insert: func(t *testing.T, tree *Tree) error {
+				require.NoError(t, tree.Insert(
+					netip.MustParsePrefix("1.0.0.0/25"), mmdbtype.String("left")))
+				require.NoError(t, tree.Insert(
+					netip.MustParsePrefix("1.0.0.128/25"), mmdbtype.String("right")))
+				calls := 0
+				return tree.InsertPureFunc(
+					netip.MustParsePrefix("1.0.0.0/24"),
+					mmdbtype.String("new"),
+					func(_, _ mmdbtype.DataType) (mmdbtype.DataType, error) {
+						calls++
+						assert.Equal(t, 1, calls, "the walk continued past the failure")
+						return nil, errors.New("inserter failure")
+					},
+				)
+			},
+		},
+		{
+			// The callback fails over an empty record wider than the insert,
+			// where a success would have created a path record.
+			name: "inserter error over a wider empty record",
+			insert: func(t *testing.T, tree *Tree) error {
+				return tree.InsertFunc(
+					netip.MustParsePrefix("1.0.0.0/24"),
+					mmdbtype.String("new"),
+					func(_, _ mmdbtype.DataType, metadata inserter.Metadata) (
+						mmdbtype.DataType,
+						error,
+					) {
+						assert.Less(t, metadata.ExistingDepth, metadata.InsertedDepth(),
+							"the empty record was not wider than the insert")
+						return nil, errors.New("inserter failure")
+					},
+				)
+			},
+		},
+		{
 			name: "invalid nested value from an inserter",
 			insert: func(t *testing.T, tree *Tree) error {
 				require.NoError(t, tree.Insert(

--- a/audit_test.go
+++ b/audit_test.go
@@ -132,7 +132,7 @@ func TestFailedInsertsPassTheAudit(t *testing.T) {
 				return tree.InsertPureFunc(
 					netip.MustParsePrefix("1.0.0.0/24"),
 					mmdbtype.String("new"),
-					func(_, newValue mmdbtype.DataType, _ inserter.Metadata) (mmdbtype.DataType, error) {
+					func(_, newValue mmdbtype.DataType) (mmdbtype.DataType, error) {
 						calls++
 						if calls == 2 {
 							return nil, errors.New("inserter failure")

--- a/errors.go
+++ b/errors.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"net/netip"
+
+	"github.com/maxmind/mmdbwriter/v2/internal/treeaddr"
 )
 
 // errNilInserterFunc is returned by the insertion methods that take an inserter
@@ -103,42 +105,10 @@ func newReservedNetworkError(
 }
 
 func prefixFromInsertIP(ip [16]byte, prefixLen, treeDepth int) (netip.Prefix, error) {
-	// Reverse Tree.addrInsertIP's byte layout so error prefixes are reported in
-	// the same address family callers inserted.
-	if treeDepth == 32 {
-		addr := netip.AddrFrom4([4]byte{ip[0], ip[1], ip[2], ip[3]})
-		return prefixFromAddr(addr, prefixLen)
-	}
-
-	if isIPv4SubtreeIP(ip) && prefixLen >= 96 {
-		addr := netip.AddrFrom4([4]byte{ip[12], ip[13], ip[14], ip[15]})
-		return prefixFromAddr(addr, prefixLen-96)
-	}
-
-	addr := netip.AddrFrom16(ip)
-	return prefixFromAddr(addr, prefixLen)
-}
-
-func prefixFromAddr(addr netip.Addr, prefixLen int) (netip.Prefix, error) {
-	prefix, err := addr.Prefix(prefixLen)
-	if err != nil {
-		return netip.Prefix{}, fmt.Errorf(
-			"creating prefix from addr %s and prefix length %d: %w",
-			addr,
-			prefixLen,
-			err,
-		)
-	}
-	return prefix, nil
-}
-
-func isIPv4SubtreeIP(ip [16]byte) bool {
-	for _, b := range ip[:12] {
-		if b != 0 {
-			return false
-		}
-	}
-	return true
+	// Keep the error path's existing family inference. Tree addresses do not
+	// encode an address family, so other callers supply their own decision.
+	as4 := treeDepth == 32 || (treeaddr.IsIPv4SubtreeIP(ip) && prefixLen >= 96)
+	return treeaddr.PrefixFromInsertIP(ip, prefixLen, treeDepth, as4)
 }
 
 func (r *ReservedNetworkError) Error() string {

--- a/inserter/inserter.go
+++ b/inserter/inserter.go
@@ -29,10 +29,9 @@ import (
 // a record and remerge it, leave a fragment of a wider record, or split empty
 // space into narrower empty records.
 //
-// ExistingDepth is set for every record. ExistingAddr is zero and
-// ExistingNetwork returns the zero Prefix when the existing record is more
-// specific than InsertedNetwork, which the walk would have to track branch
-// paths to report.
+// Every covered record reports its own extent, including records more specific
+// than InsertedNetwork. Inserting a /31 over an existing /32 therefore tells
+// the callback which of the two /32s it is resolving.
 //
 // A Metadata is inconsistent when InsertedNetwork is invalid, TreeDepth is
 // neither 32 nor 128, or a 32-bit tree carries a non-IPv4 insertion. The
@@ -65,6 +64,10 @@ type Metadata struct {
 	// and below ExistingDepth. Most callers want ExistingNetwork instead. A
 	// 32-bit tree uses bytes 0-3. A 128-bit tree uses all 16 bytes, with IPv4
 	// addresses in bytes 12-15. It is a copy, not a view of tree storage.
+	//
+	// For a record more specific than InsertedNetwork it carries the path the
+	// insertion walked to reach the record, so sibling records under one
+	// insertion have different addresses at the same ExistingDepth.
 	ExistingAddr [16]byte
 
 	// TreeDepth is 32 for an IPv4 tree and 128 for an IPv6 tree. It is needed
@@ -76,24 +79,24 @@ type Metadata struct {
 // adding 96 for an IPv4 network in an IPv6 tree. It returns 0 for an
 // inconsistent Metadata. It does not read ExistingDepth.
 func (m Metadata) InsertedDepth() int {
-	depth, _ := m.insertedDepth()
-	return depth
-}
-
-// insertedDepth returns InsertedNetwork's depth in tree bits, and reports
-// whether the fields it reads are consistent.
-func (m Metadata) insertedDepth() (int, bool) {
-	if !m.InsertedNetwork.IsValid() ||
-		(m.TreeDepth != 32 && m.TreeDepth != 128) ||
-		(m.TreeDepth == 32 && !m.InsertedNetwork.Addr().Is4()) {
-		return 0, false
+	if !m.consistent() {
+		return 0
 	}
 
 	depth := m.InsertedNetwork.Bits()
 	if m.TreeDepth == 128 && m.InsertedNetwork.Addr().Is4() {
 		depth += 96
 	}
-	return depth, true
+	return depth
+}
+
+// consistent reports whether InsertedNetwork and TreeDepth describe a
+// supported tree and address family. The insertion methods never produce an
+// inconsistent Metadata.
+func (m Metadata) consistent() bool {
+	return m.InsertedNetwork.IsValid() &&
+		(m.TreeDepth == 32 || m.TreeDepth == 128) &&
+		(m.TreeDepth != 32 || m.InsertedNetwork.Addr().Is4())
 }
 
 // ExistingNetwork returns the network of the record that held the existing
@@ -102,15 +105,10 @@ func (m Metadata) insertedDepth() (int, bool) {
 // IPv4 insert into an IPv6 tree, records shallower than the IPv4 subtree are
 // returned in IPv6 form.
 //
-// It returns the zero Prefix for an inconsistent Metadata, an ExistingDepth
-// outside [0, TreeDepth], or an existing record more specific than
-// InsertedNetwork.
+// It returns the zero Prefix for an inconsistent Metadata or an ExistingDepth
+// outside [0, TreeDepth].
 func (m Metadata) ExistingNetwork() netip.Prefix {
-	insertedDepth, ok := m.insertedDepth()
-	if !ok ||
-		m.ExistingDepth < 0 ||
-		m.ExistingDepth > m.TreeDepth ||
-		m.ExistingDepth > insertedDepth {
+	if !m.consistent() || m.ExistingDepth < 0 || m.ExistingDepth > m.TreeDepth {
 		return netip.Prefix{}
 	}
 

--- a/inserter/inserter.go
+++ b/inserter/inserter.go
@@ -87,8 +87,12 @@ type Metadata struct {
 }
 
 // InsertedDepth returns InsertedNetwork's depth in tree bits from the root,
-// adding 96 for an IPv4 network in an IPv6 tree. It returns 0 for an
-// inconsistent Metadata. It does not read ExistingDepth.
+// adding 96 for an IPv4 network in an IPv6 tree. It does not read
+// ExistingDepth.
+//
+// It returns 0 for an inconsistent Metadata, which is also the depth of a root
+// insert, so 0 does not identify one or the other. Only a hand-built Metadata
+// can be inconsistent.
 func (m Metadata) InsertedDepth() int {
 	if !m.consistent() {
 		return 0
@@ -125,8 +129,9 @@ func (m Metadata) ExistingNetwork() netip.Prefix {
 		return netip.Prefix{}
 	}
 
-	as4 := m.TreeDepth == 32 ||
-		(m.InsertedNetwork.Addr().Is4() && m.ExistingDepth >= 96)
+	// treeaddr.PrefixFromInsertIP returns from its own 32-bit tree branch
+	// before it reads as4, so this only has to answer for a 128-bit tree.
+	as4 := m.InsertedNetwork.Addr().Is4() && m.ExistingDepth >= 96
 	prefix, err := treeaddr.PrefixFromInsertIP(
 		m.ExistingAddr,
 		m.ExistingDepth,

--- a/inserter/inserter.go
+++ b/inserter/inserter.go
@@ -22,6 +22,18 @@ import (
 // not identify the network that established an existing value. A policy that
 // needs that provenance must store it in the value.
 //
+// For a range insert, each decomposed prefix is a separate insertion. Metadata
+// for a later prefix therefore reflects changes made by earlier prefixes in the
+// same range call.
+//
+// Record boundaries follow the tree's history. A wire-equal insertion can split
+// a record and immediately remerge it, so a later insertion sees the merged
+// record. An overlapping earlier insertion can leave fragments, and Metadata
+// reports the fragment it reaches. Empty records work the same way. An
+// insertion into a fresh tree can reach a wide empty record, and a neighboring
+// earlier insertion can split the same address space into narrower empty
+// records.
+//
 // Fields may be added in later releases. Construct Metadata values with keyed
 // literals.
 type Metadata struct {
@@ -113,12 +125,21 @@ func (m Metadata) ExistingNetwork() netip.Prefix {
 // Tree.InsertRangeFunc. Tree.InsertPureFunc and Tree.InsertRangePureFunc may
 // memoize repeated argument pairs and share a non-nil result across records.
 //
-// A Func must not modify either argument. The existing value is a shared,
+// metadata describes the insertion and the current tree record represented by
+// existingValue. For a range, InsertedNetwork is the individual decomposed
+// prefix. During Load, it is the normalized source-record network. The pure
+// insertion methods pass the zero Metadata because their memo is keyed only by
+// the existing value.
+//
+// A Func must not modify either value argument. The existing value is a shared,
 // read-only view of tree storage; the new value is the value passed to the
 // insert call, or a shared view of the decoded record during a load. Call
 // Copy on a value to get a private copy you can modify. Any non-nil returned
 // value becomes tree-owned and must not be modified after the function
 // returns.
+//
+// A panic propagates. The insertion methods' guarantees for callbacks that
+// return errors do not apply to a panic.
 //
 // Only direct inserts and a Func's result are validated, so a Func can
 // receive an unsupported input value, such as a raw mmdbtype.Pointer or an

--- a/inserter/inserter.go
+++ b/inserter/inserter.go
@@ -33,20 +33,31 @@ import (
 // than InsertedNetwork. Inserting a /31 over an existing /32 therefore tells
 // the callback which of the two /32s it is resolving.
 //
+// Reserved and aliased networks are the exception. An insertion that contains
+// one skips it silently, so a callback covering, for example, ::/0 never sees
+// those extents and cannot treat its calls as covering the whole insert.
+//
 // A Metadata is inconsistent when InsertedNetwork is invalid, TreeDepth is
 // neither 32 nor 128, or a 32-bit tree carries a non-IPv4 insertion. The
 // insertion methods never produce one. The methods below return zero values
 // for it, and other hand-built combinations are unspecified.
 //
+// Metadata is not comparable, and no release will make it comparable. Compare
+// individual fields instead of whole values, and do not use one as a map key.
+//
 // Fields may be added in later releases. Construct Metadata values with keyed
 // literals.
 type Metadata struct {
 	// Force keyed literals and keep Metadata non-comparable, reserving the
-	// right to add fields of any type.
+	// right to add a field of any type without breaking construction or
+	// comparison.
 	_ [0]func()
 
-	// InsertedNetwork is the network being inserted. For a range insert, it is
-	// the individual prefix into which the range decomposed.
+	// InsertedNetwork is the network being inserted, normalized: masked, and
+	// with an IPv4-mapped prefix at /96 or longer reported as IPv4. Inserting
+	// ::ffff:1.2.3.4/120 therefore reports 1.2.3.0/24, so comparing this
+	// against the prefix passed to the insert method can surprise. For a range
+	// insert, it is the individual prefix into which the range decomposed.
 	InsertedNetwork netip.Prefix
 
 	// ExistingDepth is the depth in tree bits of the record that held the
@@ -103,7 +114,9 @@ func (m Metadata) consistent() bool {
 // value, as that record stood just before this insertion. The result follows
 // the inserted network's address family, as Tree.Get follows its query. For an
 // IPv4 insert into an IPv6 tree, records shallower than the IPv4 subtree are
-// returned in IPv6 form.
+// returned in IPv6 form. A default IPv6 tree aliases the IPv4 subtree, which
+// splits the path down to depth 96, so an IPv4 insert there resolves at depth
+// 97 or deeper. Only Options.DisableIPv4Aliasing reaches a shallower record.
 //
 // It returns the zero Prefix for an inconsistent Metadata or an ExistingDepth
 // outside [0, TreeDepth].

--- a/inserter/inserter.go
+++ b/inserter/inserter.go
@@ -123,15 +123,19 @@ func (m Metadata) ExistingNetwork() netip.Prefix {
 // Only direct inserts and a Func's result are validated, so a Func can
 // receive an unsupported input value, such as a raw mmdbtype.Pointer or an
 // out-of-range mmdbtype.Uint128, and must replace or discard it.
-type Func func(existingValue, newValue mmdbtype.DataType) (mmdbtype.DataType, error)
+type Func func(
+	existingValue,
+	newValue mmdbtype.DataType,
+	metadata Metadata,
+) (mmdbtype.DataType, error)
 
 // Remove removes any records for the network being inserted.
-func Remove(_, _ mmdbtype.DataType) (mmdbtype.DataType, error) {
+func Remove(_, _ mmdbtype.DataType, _ Metadata) (mmdbtype.DataType, error) {
 	return nil, nil
 }
 
 // Replace replaces the existing value with the new value.
-func Replace(_, newValue mmdbtype.DataType) (mmdbtype.DataType, error) {
+func Replace(_, newValue mmdbtype.DataType, _ Metadata) (mmdbtype.DataType, error) {
 	return newValue, nil
 }
 
@@ -141,7 +145,11 @@ func Replace(_, newValue mmdbtype.DataType) (mmdbtype.DataType, error) {
 //
 // Both the new and existing value must be a Map. An error will be returned
 // otherwise.
-func TopLevelMerge(existingValue, newValue mmdbtype.DataType) (mmdbtype.DataType, error) {
+func TopLevelMerge(
+	existingValue,
+	newValue mmdbtype.DataType,
+	_ Metadata,
+) (mmdbtype.DataType, error) {
 	newMap, ok := newValue.(mmdbtype.Map)
 	if !ok {
 		return nil, fmt.Errorf(
@@ -174,7 +182,11 @@ func TopLevelMerge(existingValue, newValue mmdbtype.DataType) (mmdbtype.DataType
 // merged recursively. Other values will be replaced by the new value. The
 // returned value may be the existing container or retain unchanged nested
 // containers from it. The result must therefore be treated as immutable.
-func DeepMerge(existingValue, newValue mmdbtype.DataType) (mmdbtype.DataType, error) {
+func DeepMerge(
+	existingValue,
+	newValue mmdbtype.DataType,
+	_ Metadata,
+) (mmdbtype.DataType, error) {
 	value, _, err := deepMerge(existingValue, newValue)
 	return value, err
 }

--- a/inserter/inserter.go
+++ b/inserter/inserter.go
@@ -16,28 +16,28 @@ import (
 	"github.com/maxmind/mmdbwriter/v2/mmdbtype"
 )
 
-// Metadata describes the insertion an inserter is resolving, and the record
-// that insertion is about to change. That record is the one a Tree.Get for an
-// address in it would have returned just before this insertion. Metadata does
-// not identify the network that established an existing value. A policy that
-// needs that provenance must store it in the value.
+// Metadata describes the insertion an inserter is resolving and the record it
+// is about to change. That record is what a Tree.Get for an address in it would
+// have returned just before the insertion. Metadata does not identify the
+// network that established an existing value, so a policy that needs that
+// provenance must store it in the value.
 //
-// For a range insert, each decomposed prefix is a separate insertion. Metadata
-// for a later prefix therefore reflects changes made by earlier prefixes in the
-// same range call.
+// For a range insert, each decomposed prefix is a separate insertion, and
+// metadata for a later prefix reflects the changes earlier prefixes made.
 //
-// Record boundaries follow the tree's history. A wire-equal insertion can split
-// a record and immediately remerge it, so a later insertion sees the merged
-// record. An overlapping earlier insertion can leave fragments, and Metadata
-// reports the fragment it reaches. Empty records work the same way. An
-// insertion into a fresh tree can reach a wide empty record, and a neighboring
-// earlier insertion can split the same address space into narrower empty
-// records.
+// Earlier insertions shape the record boundaries reported here. They can split
+// a record and remerge it, leave a fragment of a wider record, or split empty
+// space into narrower empty records.
 //
-// For non-pure insertions, ExistingDepth is available for every record. To
-// avoid tracking branch paths on every insertion, ExistingAddr is zero and
+// ExistingDepth is set for every record. ExistingAddr is zero and
 // ExistingNetwork returns the zero Prefix when the existing record is more
-// specific than InsertedNetwork.
+// specific than InsertedNetwork, which the walk would have to track branch
+// paths to report.
+//
+// A Metadata is inconsistent when InsertedNetwork is invalid, TreeDepth is
+// neither 32 nor 128, or a 32-bit tree carries a non-IPv4 insertion. The
+// insertion methods never produce one. The methods below return zero values
+// for it, and other hand-built combinations are unspecified.
 //
 // Fields may be added in later releases. Construct Metadata values with keyed
 // literals.
@@ -47,25 +47,24 @@ type Metadata struct {
 	_ [0]func()
 
 	// InsertedNetwork is the network being inserted. For a range insert, it is
-	// the individual prefix into which the range decomposed. During Load, it is
-	// the normalized network of the source record. It is the zero Prefix for
-	// Tree.InsertPureFunc and Tree.InsertRangePureFunc.
+	// the individual prefix into which the range decomposed.
 	InsertedNetwork netip.Prefix
 
-	// ExistingDepth is the extent of the record holding the existing value, in
-	// tree bits from the root, as that record stood immediately before this
-	// insertion began mutating it. It reflects earlier splits and merges but no
-	// preparatory split made by the current insertion. Its range is
-	// [0, TreeDepth]. An IPv4 network in an IPv6 tree is 96 bits deeper than its
-	// address-family prefix length, so compare ExistingDepth with
-	// InsertedDepth(), not InsertedNetwork.Bits(). It is 0 for the pure methods.
+	// ExistingDepth is the depth in tree bits of the record that held the
+	// existing value, in [0, TreeDepth]. Each record reports its own depth, so
+	// a record wider than InsertedNetwork reports that width, not the depth
+	// this insertion splits it to: inserting a /24 over a /16 record reports
+	// the /16's depth.
+	//
+	// An IPv4 network in an IPv6 tree is 96 bits deeper than its address-family
+	// prefix length, so compare ExistingDepth with InsertedDepth(), not
+	// InsertedNetwork.Bits().
 	ExistingDepth int
 
 	// ExistingAddr is the tree-space address of the existing record, zeroed at
-	// and below ExistingDepth. A 32-bit tree uses bytes 0-3. A 128-bit tree uses
-	// all 16 bytes, with IPv4 addresses in bytes 12-15. It is a copy and remains
-	// valid after insertion returns. It is all zero when ExistingDepth is greater
-	// than InsertedDepth(). Most callers should use ExistingNetwork.
+	// and below ExistingDepth. Most callers want ExistingNetwork instead. A
+	// 32-bit tree uses bytes 0-3. A 128-bit tree uses all 16 bytes, with IPv4
+	// addresses in bytes 12-15. It is a copy, not a view of tree storage.
 	ExistingAddr [16]byte
 
 	// TreeDepth is 32 for an IPv4 tree and 128 for an IPv6 tree. It is needed
@@ -73,23 +72,28 @@ type Metadata struct {
 	TreeDepth int
 }
 
-// InsertedDepth returns InsertedNetwork's extent in tree bits from the root.
-// It adds 96 for an IPv4 network in an IPv6 tree. It returns 0 for the pure
-// methods and for an invalid InsertedNetwork, an unsupported TreeDepth, or a
-// non-IPv4 insertion in a 32-bit tree. It does not read ExistingDepth, so an
-// out-of-range ExistingDepth does not affect the result.
+// InsertedDepth returns InsertedNetwork's depth in tree bits from the root,
+// adding 96 for an IPv4 network in an IPv6 tree. It returns 0 for an
+// inconsistent Metadata. It does not read ExistingDepth.
 func (m Metadata) InsertedDepth() int {
+	depth, _ := m.insertedDepth()
+	return depth
+}
+
+// insertedDepth returns InsertedNetwork's depth in tree bits, and reports
+// whether the fields it reads are consistent.
+func (m Metadata) insertedDepth() (int, bool) {
 	if !m.InsertedNetwork.IsValid() ||
 		(m.TreeDepth != 32 && m.TreeDepth != 128) ||
 		(m.TreeDepth == 32 && !m.InsertedNetwork.Addr().Is4()) {
-		return 0
+		return 0, false
 	}
 
 	depth := m.InsertedNetwork.Bits()
 	if m.TreeDepth == 128 && m.InsertedNetwork.Addr().Is4() {
 		depth += 96
 	}
-	return depth
+	return depth, true
 }
 
 // ExistingNetwork returns the network of the record that held the existing
@@ -98,19 +102,15 @@ func (m Metadata) InsertedDepth() int {
 // IPv4 insert into an IPv6 tree, records shallower than the IPv4 subtree are
 // returned in IPv6 form.
 //
-// ExistingNetwork returns the zero Prefix for the pure methods, an invalid
-// InsertedNetwork, an unsupported TreeDepth, a non-IPv4 insertion in a 32-bit
-// tree, an ExistingDepth outside [0, TreeDepth], or an existing record more
-// specific than InsertedNetwork. Other inconsistent hand-built combinations
-// are unspecified.
+// It returns the zero Prefix for an inconsistent Metadata, an ExistingDepth
+// outside [0, TreeDepth], or an existing record more specific than
+// InsertedNetwork.
 func (m Metadata) ExistingNetwork() netip.Prefix {
-	if !m.InsertedNetwork.IsValid() ||
-		(m.TreeDepth != 32 && m.TreeDepth != 128) ||
-		(m.TreeDepth == 32 && !m.InsertedNetwork.Addr().Is4()) ||
-		m.ExistingDepth < 0 || m.ExistingDepth > m.TreeDepth {
-		return netip.Prefix{}
-	}
-	if m.ExistingDepth > m.InsertedDepth() {
+	insertedDepth, ok := m.insertedDepth()
+	if !ok ||
+		m.ExistingDepth < 0 ||
+		m.ExistingDepth > m.TreeDepth ||
+		m.ExistingDepth > insertedDepth {
 		return netip.Prefix{}
 	}
 
@@ -128,32 +128,46 @@ func (m Metadata) ExistingNetwork() netip.Prefix {
 	return prefix
 }
 
-// Func resolves an insertion into a tree record. existingValue is nil for an
-// empty record, and newValue is the value passed to the insert method. Returning
-// nil leaves the record empty or removes the existing value. A Func is evaluated
-// separately for every covered record when passed to Tree.InsertFunc or
-// Tree.InsertRangeFunc. Tree.InsertPureFunc and Tree.InsertRangePureFunc may
-// memoize repeated argument pairs and share a non-nil result across records.
+// PureFunc resolves an insertion into a tree record without receiving insertion
+// metadata. existingValue is nil for an empty record, and newValue is the value
+// passed to the insert method or decoded during Load. Returning nil leaves the
+// record empty or removes the existing value.
 //
-// metadata describes the insertion and the current tree record represented by
-// existingValue. For a range, InsertedNetwork is the individual decomposed
-// prefix. During Load, it is the normalized source-record network. The pure
-// insertion methods pass the zero Metadata because their memo is keyed only by
-// the existing value.
+// A PureFunc's result and error must depend only on its arguments. It must not
+// depend on invocation count, order, or external mutable state. Repeated
+// argument pairs may be memoized during an insertion, and a non-nil result may
+// be shared by multiple records.
 //
-// A Func must not modify either value argument. The existing value is a shared,
-// read-only view of tree storage; the new value is the value passed to the
-// insert call, or a shared view of the decoded record during a load. Call
-// Copy on a value to get a private copy you can modify. Any non-nil returned
-// value becomes tree-owned and must not be modified after the function
-// returns.
+// A PureFunc must not modify either argument. The existing value is a shared,
+// read-only view of tree storage. The new value is the value passed to the
+// insert call, or a shared view of a decoded record during Load. Call Copy on a
+// value to get a private copy you can modify. Any non-nil returned value becomes
+// tree-owned and must not be modified after the function returns.
 //
 // A panic propagates. The insertion methods' guarantees for callbacks that
 // return errors do not apply to a panic.
 //
-// Only direct inserts and a Func's result are validated, so a Func can
+// Only direct inserts and a PureFunc's result are validated, so a PureFunc can
 // receive an unsupported input value, such as a raw mmdbtype.Pointer or an
 // out-of-range mmdbtype.Uint128, and must replace or discard it.
+type PureFunc func(
+	existingValue,
+	newValue mmdbtype.DataType,
+) (mmdbtype.DataType, error)
+
+// Func resolves an insertion into a tree record. existingValue is nil for an
+// empty record, and newValue is the value passed to the insert method. Returning
+// nil leaves the record empty or removes the existing value. A Func is evaluated
+// separately for every covered record when passed to Tree.InsertFunc or
+// Tree.InsertRangeFunc.
+//
+// metadata describes the insertion and the current tree record represented by
+// existingValue. For a range, InsertedNetwork is the individual decomposed
+// prefix.
+//
+// The rules PureFunc documents for modifying values, for panics, and for
+// unvalidated input values apply here too. A Func is never memoized, because
+// its metadata varies per record.
 type Func func(
 	existingValue,
 	newValue mmdbtype.DataType,
@@ -161,12 +175,12 @@ type Func func(
 ) (mmdbtype.DataType, error)
 
 // Remove removes any records for the network being inserted.
-func Remove(_, _ mmdbtype.DataType, _ Metadata) (mmdbtype.DataType, error) {
+func Remove(_, _ mmdbtype.DataType) (mmdbtype.DataType, error) {
 	return nil, nil
 }
 
 // Replace replaces the existing value with the new value.
-func Replace(_, newValue mmdbtype.DataType, _ Metadata) (mmdbtype.DataType, error) {
+func Replace(_, newValue mmdbtype.DataType) (mmdbtype.DataType, error) {
 	return newValue, nil
 }
 
@@ -179,7 +193,6 @@ func Replace(_, newValue mmdbtype.DataType, _ Metadata) (mmdbtype.DataType, erro
 func TopLevelMerge(
 	existingValue,
 	newValue mmdbtype.DataType,
-	_ Metadata,
 ) (mmdbtype.DataType, error) {
 	newMap, ok := newValue.(mmdbtype.Map)
 	if !ok {
@@ -216,7 +229,6 @@ func TopLevelMerge(
 func DeepMerge(
 	existingValue,
 	newValue mmdbtype.DataType,
-	_ Metadata,
 ) (mmdbtype.DataType, error) {
 	value, _, err := deepMerge(existingValue, newValue)
 	return value, err

--- a/inserter/inserter.go
+++ b/inserter/inserter.go
@@ -34,6 +34,11 @@ import (
 // earlier insertion can split the same address space into narrower empty
 // records.
 //
+// For non-pure insertions, ExistingDepth is available for every record. To
+// avoid tracking branch paths on every insertion, ExistingAddr is zero and
+// ExistingNetwork returns the zero Prefix when the existing record is more
+// specific than InsertedNetwork.
+//
 // Fields may be added in later releases. Construct Metadata values with keyed
 // literals.
 type Metadata struct {
@@ -59,7 +64,8 @@ type Metadata struct {
 	// ExistingAddr is the tree-space address of the existing record, zeroed at
 	// and below ExistingDepth. A 32-bit tree uses bytes 0-3. A 128-bit tree uses
 	// all 16 bytes, with IPv4 addresses in bytes 12-15. It is a copy and remains
-	// valid after insertion returns. Most callers should use ExistingNetwork.
+	// valid after insertion returns. It is all zero when ExistingDepth is greater
+	// than InsertedDepth(). Most callers should use ExistingNetwork.
 	ExistingAddr [16]byte
 
 	// TreeDepth is 32 for an IPv4 tree and 128 for an IPv6 tree. It is needed
@@ -94,13 +100,17 @@ func (m Metadata) InsertedDepth() int {
 //
 // ExistingNetwork returns the zero Prefix for the pure methods, an invalid
 // InsertedNetwork, an unsupported TreeDepth, a non-IPv4 insertion in a 32-bit
-// tree, or an ExistingDepth outside [0, TreeDepth]. Other inconsistent
-// hand-built combinations are unspecified.
+// tree, an ExistingDepth outside [0, TreeDepth], or an existing record more
+// specific than InsertedNetwork. Other inconsistent hand-built combinations
+// are unspecified.
 func (m Metadata) ExistingNetwork() netip.Prefix {
 	if !m.InsertedNetwork.IsValid() ||
 		(m.TreeDepth != 32 && m.TreeDepth != 128) ||
 		(m.TreeDepth == 32 && !m.InsertedNetwork.Addr().Is4()) ||
 		m.ExistingDepth < 0 || m.ExistingDepth > m.TreeDepth {
+		return netip.Prefix{}
+	}
+	if m.ExistingDepth > m.InsertedDepth() {
 		return netip.Prefix{}
 	}
 

--- a/inserter/inserter.go
+++ b/inserter/inserter.go
@@ -10,9 +10,101 @@ package inserter
 import (
 	"fmt"
 	"maps"
+	"net/netip"
 
+	"github.com/maxmind/mmdbwriter/v2/internal/treeaddr"
 	"github.com/maxmind/mmdbwriter/v2/mmdbtype"
 )
+
+// Metadata describes the insertion an inserter is resolving, and the record
+// that insertion is about to change. That record is the one a Tree.Get for an
+// address in it would have returned just before this insertion. Metadata does
+// not identify the network that established an existing value. A policy that
+// needs that provenance must store it in the value.
+//
+// Fields may be added in later releases. Construct Metadata values with keyed
+// literals.
+type Metadata struct {
+	// Force keyed literals and keep Metadata non-comparable, reserving the
+	// right to add fields of any type.
+	_ [0]func()
+
+	// InsertedNetwork is the network being inserted. For a range insert, it is
+	// the individual prefix into which the range decomposed. During Load, it is
+	// the normalized network of the source record. It is the zero Prefix for
+	// Tree.InsertPureFunc and Tree.InsertRangePureFunc.
+	InsertedNetwork netip.Prefix
+
+	// ExistingDepth is the extent of the record holding the existing value, in
+	// tree bits from the root, as that record stood immediately before this
+	// insertion began mutating it. It reflects earlier splits and merges but no
+	// preparatory split made by the current insertion. Its range is
+	// [0, TreeDepth]. An IPv4 network in an IPv6 tree is 96 bits deeper than its
+	// address-family prefix length, so compare ExistingDepth with
+	// InsertedDepth(), not InsertedNetwork.Bits(). It is 0 for the pure methods.
+	ExistingDepth int
+
+	// ExistingAddr is the tree-space address of the existing record, zeroed at
+	// and below ExistingDepth. A 32-bit tree uses bytes 0-3. A 128-bit tree uses
+	// all 16 bytes, with IPv4 addresses in bytes 12-15. It is a copy and remains
+	// valid after insertion returns. Most callers should use ExistingNetwork.
+	ExistingAddr [16]byte
+
+	// TreeDepth is 32 for an IPv4 tree and 128 for an IPv6 tree. It is needed
+	// to interpret ExistingAddr's layout.
+	TreeDepth int
+}
+
+// InsertedDepth returns InsertedNetwork's extent in tree bits from the root.
+// It adds 96 for an IPv4 network in an IPv6 tree. It returns 0 for the pure
+// methods and for an invalid InsertedNetwork, an unsupported TreeDepth, or a
+// non-IPv4 insertion in a 32-bit tree. It does not read ExistingDepth, so an
+// out-of-range ExistingDepth does not affect the result.
+func (m Metadata) InsertedDepth() int {
+	if !m.InsertedNetwork.IsValid() ||
+		(m.TreeDepth != 32 && m.TreeDepth != 128) ||
+		(m.TreeDepth == 32 && !m.InsertedNetwork.Addr().Is4()) {
+		return 0
+	}
+
+	depth := m.InsertedNetwork.Bits()
+	if m.TreeDepth == 128 && m.InsertedNetwork.Addr().Is4() {
+		depth += 96
+	}
+	return depth
+}
+
+// ExistingNetwork returns the network of the record that held the existing
+// value, as that record stood just before this insertion. The result follows
+// the inserted network's address family, as Tree.Get follows its query. For an
+// IPv4 insert into an IPv6 tree, records shallower than the IPv4 subtree are
+// returned in IPv6 form.
+//
+// ExistingNetwork returns the zero Prefix for the pure methods, an invalid
+// InsertedNetwork, an unsupported TreeDepth, a non-IPv4 insertion in a 32-bit
+// tree, or an ExistingDepth outside [0, TreeDepth]. Other inconsistent
+// hand-built combinations are unspecified.
+func (m Metadata) ExistingNetwork() netip.Prefix {
+	if !m.InsertedNetwork.IsValid() ||
+		(m.TreeDepth != 32 && m.TreeDepth != 128) ||
+		(m.TreeDepth == 32 && !m.InsertedNetwork.Addr().Is4()) ||
+		m.ExistingDepth < 0 || m.ExistingDepth > m.TreeDepth {
+		return netip.Prefix{}
+	}
+
+	as4 := m.TreeDepth == 32 ||
+		(m.InsertedNetwork.Addr().Is4() && m.ExistingDepth >= 96)
+	prefix, err := treeaddr.PrefixFromInsertIP(
+		m.ExistingAddr,
+		m.ExistingDepth,
+		m.TreeDepth,
+		as4,
+	)
+	if err != nil {
+		return netip.Prefix{}
+	}
+	return prefix
+}
 
 // Func resolves an insertion into a tree record. existingValue is nil for an
 // empty record, and newValue is the value passed to the insert method. Returning

--- a/inserter/inserter_test.go
+++ b/inserter/inserter_test.go
@@ -14,13 +14,13 @@ import (
 var benchmarkMergeValue mmdbtype.DataType
 
 func TestRemove(t *testing.T) {
-	v, err := Remove(mmdbtype.Map{}, mmdbtype.Map{}, Metadata{})
+	v, err := Remove(mmdbtype.Map{}, mmdbtype.Map{})
 	require.NoError(t, err)
 	assert.Nil(t, v)
 }
 
 func TestReplace(t *testing.T) {
-	v, err := Replace(mmdbtype.Bool(true), mmdbtype.Uint64(1), Metadata{})
+	v, err := Replace(mmdbtype.Bool(true), mmdbtype.Uint64(1))
 	require.NoError(t, err)
 	assert.Equal(t, mmdbtype.Uint64(1), v)
 }
@@ -86,7 +86,7 @@ func TestTopLevelMerge(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		v, err := TopLevelMerge(test.existing, test.new, Metadata{})
+		v, err := TopLevelMerge(test.existing, test.new)
 		if test.expectedErr != "" {
 			require.EqualError(t, err, test.expectedErr)
 		} else {
@@ -104,7 +104,7 @@ func BenchmarkTopLevelMergeOverwriteHeavy(b *testing.B) {
 	b.ResetTimer()
 
 	for range b.N {
-		value, err := TopLevelMerge(existing, newValue, Metadata{})
+		value, err := TopLevelMerge(existing, newValue)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -120,7 +120,7 @@ func BenchmarkTopLevelMergeAdditive(b *testing.B) {
 	b.ResetTimer()
 
 	for range b.N {
-		value, err := TopLevelMerge(existing, newValue, Metadata{})
+		value, err := TopLevelMerge(existing, newValue)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -136,7 +136,7 @@ func BenchmarkDeepMergeNestedOverwrite(b *testing.B) {
 	b.ResetTimer()
 
 	for range b.N {
-		value, err := DeepMerge(existing, newValue, Metadata{})
+		value, err := DeepMerge(existing, newValue)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -152,7 +152,7 @@ func BenchmarkDeepMergeNestedAdditive(b *testing.B) {
 	b.ResetTimer()
 
 	for range b.N {
-		value, err := DeepMerge(existing, newValue, Metadata{})
+		value, err := DeepMerge(existing, newValue)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -271,7 +271,7 @@ func TestDeepMerge(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		v, err := DeepMerge(test.existing, test.new, Metadata{})
+		v, err := DeepMerge(test.existing, test.new)
 		if test.expectedErr != "" {
 			require.EqualError(t, err, test.expectedErr)
 		} else {
@@ -291,7 +291,7 @@ func TestDeepMergeReturnsExistingContainersWhenUnchanged(t *testing.T) {
 		"slice": mmdbtype.Slice{
 			mmdbtype.Map{"value": mmdbtype.String("unchanged")},
 		},
-	}, Metadata{})
+	})
 	require.NoError(t, err)
 
 	mergedMap := merged.(mmdbtype.Map)
@@ -311,7 +311,7 @@ func TestDeepMergeReusesUnchangedNestedContainers(t *testing.T) {
 	existingSnapshot := existing.Copy()
 	merged, err := DeepMerge(existing, mmdbtype.Map{
 		"changed": mmdbtype.String("new"),
-	}, Metadata{})
+	})
 	require.NoError(t, err)
 
 	assert.Equal(t, existingSnapshot, existing, "the existing value was modified")

--- a/inserter/inserter_test.go
+++ b/inserter/inserter_test.go
@@ -14,13 +14,13 @@ import (
 var benchmarkMergeValue mmdbtype.DataType
 
 func TestRemove(t *testing.T) {
-	v, err := Remove(mmdbtype.Map{}, mmdbtype.Map{})
+	v, err := Remove(mmdbtype.Map{}, mmdbtype.Map{}, Metadata{})
 	require.NoError(t, err)
 	assert.Nil(t, v)
 }
 
 func TestReplace(t *testing.T) {
-	v, err := Replace(mmdbtype.Bool(true), mmdbtype.Uint64(1))
+	v, err := Replace(mmdbtype.Bool(true), mmdbtype.Uint64(1), Metadata{})
 	require.NoError(t, err)
 	assert.Equal(t, mmdbtype.Uint64(1), v)
 }
@@ -86,7 +86,7 @@ func TestTopLevelMerge(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		v, err := TopLevelMerge(test.existing, test.new)
+		v, err := TopLevelMerge(test.existing, test.new, Metadata{})
 		if test.expectedErr != "" {
 			require.EqualError(t, err, test.expectedErr)
 		} else {
@@ -104,7 +104,7 @@ func BenchmarkTopLevelMergeOverwriteHeavy(b *testing.B) {
 	b.ResetTimer()
 
 	for range b.N {
-		value, err := TopLevelMerge(existing, newValue)
+		value, err := TopLevelMerge(existing, newValue, Metadata{})
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -120,7 +120,7 @@ func BenchmarkTopLevelMergeAdditive(b *testing.B) {
 	b.ResetTimer()
 
 	for range b.N {
-		value, err := TopLevelMerge(existing, newValue)
+		value, err := TopLevelMerge(existing, newValue, Metadata{})
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -136,7 +136,7 @@ func BenchmarkDeepMergeNestedOverwrite(b *testing.B) {
 	b.ResetTimer()
 
 	for range b.N {
-		value, err := DeepMerge(existing, newValue)
+		value, err := DeepMerge(existing, newValue, Metadata{})
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -152,7 +152,7 @@ func BenchmarkDeepMergeNestedAdditive(b *testing.B) {
 	b.ResetTimer()
 
 	for range b.N {
-		value, err := DeepMerge(existing, newValue)
+		value, err := DeepMerge(existing, newValue, Metadata{})
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -271,7 +271,7 @@ func TestDeepMerge(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		v, err := DeepMerge(test.existing, test.new)
+		v, err := DeepMerge(test.existing, test.new, Metadata{})
 		if test.expectedErr != "" {
 			require.EqualError(t, err, test.expectedErr)
 		} else {
@@ -291,7 +291,7 @@ func TestDeepMergeReturnsExistingContainersWhenUnchanged(t *testing.T) {
 		"slice": mmdbtype.Slice{
 			mmdbtype.Map{"value": mmdbtype.String("unchanged")},
 		},
-	})
+	}, Metadata{})
 	require.NoError(t, err)
 
 	mergedMap := merged.(mmdbtype.Map)
@@ -311,7 +311,7 @@ func TestDeepMergeReusesUnchangedNestedContainers(t *testing.T) {
 	existingSnapshot := existing.Copy()
 	merged, err := DeepMerge(existing, mmdbtype.Map{
 		"changed": mmdbtype.String("new"),
-	})
+	}, Metadata{})
 	require.NoError(t, err)
 
 	assert.Equal(t, existingSnapshot, existing, "the existing value was modified")

--- a/inserter/metadata_test.go
+++ b/inserter/metadata_test.go
@@ -79,6 +79,16 @@ func TestMetadataDerivedMethods(t *testing.T) {
 			expectedExistingNetwork: netip.MustParsePrefix("1.2.3.0/24"),
 		},
 		{
+			name: "more specific existing record",
+			metadata: Metadata{
+				InsertedNetwork: netip.MustParsePrefix("1.2.3.0/24"),
+				ExistingDepth:   25,
+				ExistingAddr:    v4Addr,
+				TreeDepth:       32,
+			},
+			expectedInsertedDepth: 24,
+		},
+		{
 			name: "IPv4 insertion in IPv6 tree",
 			metadata: Metadata{
 				InsertedNetwork: netip.MustParsePrefix("1.0.0.0/16"),

--- a/inserter/metadata_test.go
+++ b/inserter/metadata_test.go
@@ -86,7 +86,8 @@ func TestMetadataDerivedMethods(t *testing.T) {
 				ExistingAddr:    v4Addr,
 				TreeDepth:       32,
 			},
-			expectedInsertedDepth: 24,
+			expectedInsertedDepth:   24,
+			expectedExistingNetwork: netip.MustParsePrefix("1.2.3.0/25"),
 		},
 		{
 			name: "IPv4 insertion in IPv6 tree",

--- a/inserter/metadata_test.go
+++ b/inserter/metadata_test.go
@@ -1,0 +1,121 @@
+package inserter
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMetadataDerivedMethods(t *testing.T) {
+	v4Addr := [16]byte{1, 2, 3}
+	v4InV6Addr := [16]byte{12: 1}
+	v6Addr := netip.MustParseAddr("2001:db8:1234::").As16()
+	tests := []struct {
+		name                    string
+		metadata                Metadata
+		expectedInsertedDepth   int
+		expectedExistingNetwork netip.Prefix
+	}{
+		{
+			name:     "zero value",
+			metadata: Metadata{},
+		},
+		{
+			name: "invalid inserted network",
+			metadata: Metadata{
+				ExistingDepth: 24,
+				ExistingAddr:  v4Addr,
+				TreeDepth:     32,
+			},
+		},
+		{
+			name: "invalid tree depth",
+			metadata: Metadata{
+				InsertedNetwork: netip.MustParsePrefix("1.2.3.0/24"),
+				ExistingDepth:   24,
+				ExistingAddr:    v4Addr,
+				TreeDepth:       64,
+			},
+		},
+		{
+			name: "IPv6 insertion in IPv4 tree",
+			metadata: Metadata{
+				InsertedNetwork: netip.MustParsePrefix("2001:db8::/32"),
+				ExistingDepth:   24,
+				ExistingAddr:    v4Addr,
+				TreeDepth:       32,
+			},
+		},
+		{
+			name: "out of range existing depth",
+			metadata: Metadata{
+				InsertedNetwork: netip.MustParsePrefix("1.2.3.0/24"),
+				ExistingDepth:   33,
+				ExistingAddr:    v4Addr,
+				TreeDepth:       32,
+			},
+			expectedInsertedDepth: 24,
+		},
+		{
+			name: "negative existing depth",
+			metadata: Metadata{
+				InsertedNetwork: netip.MustParsePrefix("1.2.3.0/24"),
+				ExistingDepth:   -1,
+				ExistingAddr:    v4Addr,
+				TreeDepth:       32,
+			},
+			expectedInsertedDepth: 24,
+		},
+		{
+			name: "IPv4 tree",
+			metadata: Metadata{
+				InsertedNetwork: netip.MustParsePrefix("1.2.3.0/25"),
+				ExistingDepth:   24,
+				ExistingAddr:    v4Addr,
+				TreeDepth:       32,
+			},
+			expectedInsertedDepth:   25,
+			expectedExistingNetwork: netip.MustParsePrefix("1.2.3.0/24"),
+		},
+		{
+			name: "IPv4 insertion in IPv6 tree",
+			metadata: Metadata{
+				InsertedNetwork: netip.MustParsePrefix("1.0.0.0/16"),
+				ExistingDepth:   104,
+				ExistingAddr:    v4InV6Addr,
+				TreeDepth:       128,
+			},
+			expectedInsertedDepth:   112,
+			expectedExistingNetwork: netip.MustParsePrefix("1.0.0.0/8"),
+		},
+		{
+			name: "IPv4 insertion above IPv4 subtree",
+			metadata: Metadata{
+				InsertedNetwork: netip.MustParsePrefix("1.0.0.0/16"),
+				ExistingDepth:   1,
+				TreeDepth:       128,
+			},
+			expectedInsertedDepth:   112,
+			expectedExistingNetwork: netip.MustParsePrefix("::/1"),
+		},
+		{
+			name: "IPv6 tree",
+			metadata: Metadata{
+				InsertedNetwork: netip.MustParsePrefix("2001:db8::/48"),
+				ExistingDepth:   32,
+				ExistingAddr:    v6Addr,
+				TreeDepth:       128,
+			},
+			expectedInsertedDepth:   48,
+			expectedExistingNetwork: netip.MustParsePrefix("2001:db8::/32"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expectedInsertedDepth, test.metadata.InsertedDepth())
+			assert.Equal(t, test.expectedExistingNetwork, test.metadata.ExistingNetwork())
+		})
+	}
+}

--- a/inserter/metadata_test.go
+++ b/inserter/metadata_test.go
@@ -101,6 +101,19 @@ func TestMetadataDerivedMethods(t *testing.T) {
 			expectedExistingNetwork: netip.MustParsePrefix("1.0.0.0/8"),
 		},
 		{
+			// Depth 96 is the IPv4 subtree root, the exact hinge of the
+			// follow-the-insert family rule: at 96 the result is IPv4, and one
+			// bit shallower it is IPv6.
+			name: "IPv4 insertion at the IPv4 subtree root",
+			metadata: Metadata{
+				InsertedNetwork: netip.MustParsePrefix("1.0.0.0/16"),
+				ExistingDepth:   96,
+				TreeDepth:       128,
+			},
+			expectedInsertedDepth:   112,
+			expectedExistingNetwork: netip.MustParsePrefix("0.0.0.0/0"),
+		},
+		{
 			name: "IPv4 insertion above IPv4 subtree",
 			metadata: Metadata{
 				InsertedNetwork: netip.MustParsePrefix("1.0.0.0/16"),

--- a/internal/treeaddr/treeaddr.go
+++ b/internal/treeaddr/treeaddr.go
@@ -1,0 +1,55 @@
+// Package treeaddr converts between the byte layout used by the search tree
+// and netip prefixes.
+package treeaddr
+
+import (
+	"fmt"
+	"net/netip"
+)
+
+// PrefixFromInsertIP reverses the search tree's address layout. The as4
+// argument selects an IPv4 result for a 128-bit tree. A 32-bit tree always
+// returns an IPv4 prefix.
+func PrefixFromInsertIP(
+	ip [16]byte,
+	prefixLen,
+	treeDepth int,
+	as4 bool,
+) (netip.Prefix, error) {
+	if treeDepth == 32 {
+		addr := netip.AddrFrom4([4]byte{ip[0], ip[1], ip[2], ip[3]})
+		return prefixFromAddr(addr, prefixLen)
+	}
+
+	if as4 {
+		addr := netip.AddrFrom4([4]byte{ip[12], ip[13], ip[14], ip[15]})
+		return prefixFromAddr(addr, prefixLen-96)
+	}
+
+	addr := netip.AddrFrom16(ip)
+	return prefixFromAddr(addr, prefixLen)
+}
+
+func prefixFromAddr(addr netip.Addr, prefixLen int) (netip.Prefix, error) {
+	prefix, err := addr.Prefix(prefixLen)
+	if err != nil {
+		return netip.Prefix{}, fmt.Errorf(
+			"creating prefix from addr %s and prefix length %d: %w",
+			addr,
+			prefixLen,
+			err,
+		)
+	}
+	return prefix, nil
+}
+
+// IsIPv4SubtreeIP reports whether ip is in the IPv4 subtree of a 128-bit
+// search tree.
+func IsIPv4SubtreeIP(ip [16]byte) bool {
+	for _, b := range ip[:12] {
+		if b != 0 {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/treeaddr/treeaddr_test.go
+++ b/internal/treeaddr/treeaddr_test.go
@@ -1,0 +1,112 @@
+package treeaddr
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrefixFromInsertIP(t *testing.T) {
+	v4 := [16]byte{1, 2, 3, 0}
+	v4InV6 := [16]byte{12: 1, 13: 2, 14: 3}
+	v6 := [16]byte{0x20, 0x01, 0x0d, 0xb8}
+
+	tests := []struct {
+		name      string
+		ip        [16]byte
+		prefixLen int
+		treeDepth int
+		as4       bool
+		expected  string
+		wantErr   bool
+	}{
+		{
+			name:      "32-bit tree ignores as4",
+			ip:        v4,
+			prefixLen: 24,
+			treeDepth: 32,
+			expected:  "1.2.3.0/24",
+		},
+		{
+			name:      "32-bit tree with as4 set",
+			ip:        v4,
+			prefixLen: 24,
+			treeDepth: 32,
+			as4:       true,
+			expected:  "1.2.3.0/24",
+		},
+		{
+			name:      "IPv4 in a 128-bit tree",
+			ip:        v4InV6,
+			prefixLen: 120,
+			treeDepth: 128,
+			as4:       true,
+			expected:  "1.2.3.0/24",
+		},
+		{
+			name:      "IPv4 subtree root",
+			ip:        v4InV6,
+			prefixLen: 96,
+			treeDepth: 128,
+			as4:       true,
+			expected:  "0.0.0.0/0",
+		},
+		{
+			name:      "IPv6 in a 128-bit tree",
+			ip:        v6,
+			prefixLen: 32,
+			treeDepth: 128,
+			expected:  "2001:db8::/32",
+		},
+		{
+			// The same bytes decode as either family, which is why the caller
+			// decides rather than the layout.
+			name:      "IPv4-shaped bytes read as IPv6",
+			ip:        v4InV6,
+			prefixLen: 120,
+			treeDepth: 128,
+			expected:  "::1.2.3.0/120",
+		},
+		{
+			// Callers must not ask for IPv4 above the subtree: 40-96 is
+			// negative, which Addr.Prefix rejects.
+			name:      "as4 shallower than the IPv4 subtree",
+			ip:        v4InV6,
+			prefixLen: 40,
+			treeDepth: 128,
+			as4:       true,
+			wantErr:   true,
+		},
+		{
+			name:      "prefix length past the tree depth",
+			ip:        v4,
+			prefixLen: 33,
+			treeDepth: 32,
+			wantErr:   true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			prefix, err := PrefixFromInsertIP(test.ip, test.prefixLen, test.treeDepth, test.as4)
+			if test.wantErr {
+				require.Error(t, err)
+				assert.Equal(t, netip.Prefix{}, prefix)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, netip.MustParsePrefix(test.expected), prefix)
+		})
+	}
+}
+
+func TestIsIPv4SubtreeIP(t *testing.T) {
+	assert.True(t, IsIPv4SubtreeIP([16]byte{12: 1, 13: 2, 14: 3, 15: 4}))
+	assert.True(t, IsIPv4SubtreeIP([16]byte{}))
+	assert.False(t, IsIPv4SubtreeIP([16]byte{0x20, 0x01}))
+	// A genuine IPv6 address inside ::/96 satisfies the test, which is why
+	// callers that know the family should not use it. See ENG-5302.
+	assert.True(t, IsIPv4SubtreeIP([16]byte{15: 1}))
+}

--- a/metadata_test.go
+++ b/metadata_test.go
@@ -2,7 +2,6 @@ package mmdbwriter
 
 import (
 	"bytes"
-	"encoding/binary"
 	"errors"
 	"net/netip"
 	"slices"
@@ -108,7 +107,6 @@ func TestInserterMetadataRecordShapes(t *testing.T) {
 		require.NoError(t, tree.InsertFunc(prefix, mmdbtype.String("new"), captureMetadata(&calls)))
 
 		require.Len(t, calls, 1)
-		assert.Equal(t, calls[0].metadata.InsertedDepth(), calls[0].metadata.ExistingDepth)
 		assertMetadata(t, calls[0].metadata, prefix.String(), prefix.String(), 24, 32)
 	})
 }
@@ -310,33 +308,6 @@ func TestInserterMetadataUnaliasedIPv6ShallowRecord(t *testing.T) {
 	assert.Nil(t, calls[0].existing)
 	assertMetadata(t, calls[0].metadata, "1.2.3.0/24", "::/1", 1, 128)
 	assert.Equal(t, 120, calls[0].metadata.InsertedDepth())
-}
-
-func TestInserterMetadataNarrowerRecordNetworkFallback(t *testing.T) {
-	tree := newMetadataTree(t, Options{IPVersion: 4})
-	expectedNetworks := []netip.Prefix{
-		netip.MustParsePrefix("1.2.3.0/26"),
-		netip.MustParsePrefix("1.2.3.64/26"),
-		netip.MustParsePrefix("1.2.3.128/26"),
-		netip.MustParsePrefix("1.2.3.192/26"),
-	}
-	for index, prefix := range expectedNetworks {
-		require.NoError(t, tree.Insert(prefix, mmdbtype.Uint32(index)))
-	}
-
-	var calls []metadataCall
-	require.NoError(t, tree.InsertFunc(
-		netip.MustParsePrefix("1.2.3.0/24"),
-		mmdbtype.String("overlay"),
-		captureExisting(&calls),
-	))
-
-	require.Len(t, calls, len(expectedNetworks))
-	for index, network := range expectedNetworks {
-		assert.Equal(t, 26, calls[index].metadata.ExistingDepth)
-		assert.Equal(t, network, calls[index].metadata.ExistingNetwork())
-		assert.Equal(t, treeAddr(network, 32), calls[index].metadata.ExistingAddr)
-	}
 }
 
 func TestInserterMetadataFamilyFollowsInsert(t *testing.T) {
@@ -867,12 +838,6 @@ func metadataOracleRecords(
 		records[len(records)-1].metadata.ExistingAddr = treeAddr(existingNetwork, 32)
 	}
 	return records
-}
-
-func ipv4Addr(value uint32) netip.Addr {
-	var address [4]byte
-	binary.BigEndian.PutUint32(address[:], value)
-	return netip.AddrFrom4(address)
 }
 
 const provenancePrefixLengthKey mmdbtype.String = "_prefix_length"

--- a/metadata_test.go
+++ b/metadata_test.go
@@ -42,15 +42,13 @@ func TestInserterMetadataRecordShapes(t *testing.T) {
 
 	t.Run("narrower existing records", func(t *testing.T) {
 		tree := newMetadataTree(t, Options{IPVersion: 4})
-		for index, network := range []string{
-			"1.2.3.0/26",
-			"1.2.3.64/26",
-			"1.2.3.128/25",
-		} {
-			require.NoError(t, tree.Insert(
-				netip.MustParsePrefix(network),
-				mmdbtype.Uint32(index+1),
-			))
+		existing := []netip.Prefix{
+			netip.MustParsePrefix("1.2.3.0/26"),
+			netip.MustParsePrefix("1.2.3.64/26"),
+			netip.MustParsePrefix("1.2.3.128/25"),
+		}
+		for index, network := range existing {
+			require.NoError(t, tree.Insert(network, mmdbtype.Uint32(index+1)))
 		}
 
 		var calls []metadataCall
@@ -60,14 +58,44 @@ func TestInserterMetadataRecordShapes(t *testing.T) {
 			captureMetadata(&calls),
 		))
 
-		require.Len(t, calls, 3)
-		for index, expectedDepth := range []int{26, 26, 25} {
+		// Each record reports its own network, so a callback can tell the
+		// covered records apart even though all of them are more specific
+		// than the insert.
+		require.Len(t, calls, len(existing))
+		for index, network := range existing {
 			metadata := calls[index].metadata
 			assert.Equal(t, netip.MustParsePrefix("1.2.3.0/24"), metadata.InsertedNetwork)
-			assert.Equal(t, expectedDepth, metadata.ExistingDepth)
+			assert.Equal(t, network.Bits(), metadata.ExistingDepth)
 			assert.Equal(t, 32, metadata.TreeDepth)
-			assert.Equal(t, netip.Prefix{}, metadata.ExistingNetwork())
-			assert.Equal(t, [16]byte{}, metadata.ExistingAddr)
+			assert.Equal(t, network, metadata.ExistingNetwork())
+			assert.Equal(t, treeAddr(network, 32), metadata.ExistingAddr)
+		}
+	})
+
+	t.Run("sibling records under one insert", func(t *testing.T) {
+		tree := newMetadataTree(t, Options{IPVersion: 4})
+		require.NoError(t, tree.Insert(
+			netip.MustParsePrefix("1.1.1.1/32"),
+			mmdbtype.String("existing"),
+		))
+
+		var calls []metadataCall
+		require.NoError(t, tree.InsertFunc(
+			netip.MustParsePrefix("1.1.1.0/31"),
+			mmdbtype.String("overlay"),
+			captureMetadata(&calls),
+		))
+
+		// Both /32s report the same depth, so only the network distinguishes
+		// the empty sibling from the record that holds the existing value.
+		require.Len(t, calls, 2)
+		assert.Nil(t, calls[0].existing)
+		assert.Equal(t, netip.MustParsePrefix("1.1.1.0/32"), calls[0].metadata.ExistingNetwork())
+		assert.Equal(t, mmdbtype.String("existing"), calls[1].existing)
+		assert.Equal(t, netip.MustParsePrefix("1.1.1.1/32"), calls[1].metadata.ExistingNetwork())
+		for _, call := range calls {
+			assert.Equal(t, 32, call.metadata.ExistingDepth)
+			assert.Equal(t, 31, call.metadata.InsertedDepth())
 		}
 	})
 
@@ -234,13 +262,8 @@ func TestInserterMetadataRangeSubnets(t *testing.T) {
 		assert.Equal(t, prefix, metadata.InsertedNetwork)
 		assert.Equal(t, prefix.Bits(), metadata.InsertedDepth())
 		assert.Equal(t, expectedExisting[index].Bits(), metadata.ExistingDepth)
-		if expectedExisting[index].Bits() > prefix.Bits() {
-			assert.Equal(t, netip.Prefix{}, metadata.ExistingNetwork())
-			assert.Equal(t, [16]byte{}, metadata.ExistingAddr)
-		} else {
-			assert.Equal(t, expectedExisting[index], metadata.ExistingNetwork())
-			assert.Equal(t, treeAddr(expectedExisting[index], 32), metadata.ExistingAddr)
-		}
+		assert.Equal(t, expectedExisting[index], metadata.ExistingNetwork())
+		assert.Equal(t, treeAddr(expectedExisting[index], 32), metadata.ExistingAddr)
 		assert.Equal(t, 32, metadata.TreeDepth)
 	}
 }
@@ -309,10 +332,10 @@ func TestInserterMetadataNarrowerRecordNetworkFallback(t *testing.T) {
 	))
 
 	require.Len(t, calls, len(expectedNetworks))
-	for index := range expectedNetworks {
+	for index, network := range expectedNetworks {
 		assert.Equal(t, 26, calls[index].metadata.ExistingDepth)
-		assert.Equal(t, netip.Prefix{}, calls[index].metadata.ExistingNetwork())
-		assert.Equal(t, [16]byte{}, calls[index].metadata.ExistingAddr)
+		assert.Equal(t, network, calls[index].metadata.ExistingNetwork())
+		assert.Equal(t, treeAddr(network, 32), calls[index].metadata.ExistingAddr)
 	}
 }
 
@@ -352,8 +375,9 @@ func TestInserterMetadataFamilyFollowsInsert(t *testing.T) {
 	})
 	require.NotEqual(t, -1, index)
 	assert.Equal(t, 100, allCalls[index].metadata.ExistingDepth)
-	assert.Equal(t, netip.Prefix{}, allCalls[index].metadata.ExistingNetwork())
-	assert.Equal(t, [16]byte{}, allCalls[index].metadata.ExistingAddr)
+	// The record is the IPv4 subtree's 0.0.0.0/4, reported in IPv6 form
+	// because the insert is IPv6.
+	assert.Equal(t, netip.MustParsePrefix("::/100"), allCalls[index].metadata.ExistingNetwork())
 }
 
 func TestInserterMetadataRootInsert(t *testing.T) {
@@ -367,11 +391,17 @@ func TestInserterMetadataRootInsert(t *testing.T) {
 		mmdbtype.String("root"),
 		captureMetadata(&calls),
 	))
+	// The insert covers both root children, which the callback tells apart by
+	// the branch the walk took to reach each one.
 	require.Len(t, calls, 2)
-	for _, call := range calls {
+	expected := []netip.Prefix{
+		netip.MustParsePrefix("::/1"),
+		netip.MustParsePrefix("8000::/1"),
+	}
+	for index, call := range calls {
 		assert.Equal(t, 1, call.metadata.ExistingDepth)
-		assert.Equal(t, netip.Prefix{}, call.metadata.ExistingNetwork())
-		assert.Equal(t, [16]byte{}, call.metadata.ExistingAddr)
+		assert.Equal(t, expected[index], call.metadata.ExistingNetwork())
+		assert.Equal(t, treeAddr(expected[index], 128), call.metadata.ExistingAddr)
 	}
 }
 
@@ -815,9 +845,7 @@ func metadataOracleRecords(
 				TreeDepth:       32,
 			},
 		})
-		if existingNetwork.Bits() <= insertedNetwork.Bits() {
-			records[len(records)-1].metadata.ExistingAddr = treeAddr(existingNetwork, 32)
-		}
+		records[len(records)-1].metadata.ExistingAddr = treeAddr(existingNetwork, 32)
 	}
 	return records
 }

--- a/metadata_test.go
+++ b/metadata_test.go
@@ -71,6 +71,28 @@ func TestInserterMetadataRecordShapes(t *testing.T) {
 		}
 	})
 
+	t.Run("non-aligned existing depth", func(t *testing.T) {
+		tree := newMetadataTree(t, Options{IPVersion: 4})
+		require.NoError(t, tree.Insert(
+			netip.MustParsePrefix("1.2.3.128/25"),
+			mmdbtype.String("existing"),
+		))
+
+		var calls []metadataCall
+		require.NoError(t, tree.InsertFunc(
+			netip.MustParsePrefix("1.2.3.224/27"),
+			mmdbtype.String("overlay"),
+			captureMetadata(&calls),
+		))
+
+		// The raw address at a depth that ends mid-byte, asserted without
+		// going through ExistingNetwork, whose Prefix call would re-mask and
+		// hide a masking error.
+		require.Len(t, calls, 1)
+		assert.Equal(t, 25, calls[0].metadata.ExistingDepth)
+		assert.Equal(t, [16]byte{1, 2, 3, 128}, calls[0].metadata.ExistingAddr)
+	})
+
 	t.Run("sibling records under one insert", func(t *testing.T) {
 		tree := newMetadataTree(t, Options{IPVersion: 4})
 		require.NoError(t, tree.Insert(

--- a/metadata_test.go
+++ b/metadata_test.go
@@ -751,6 +751,25 @@ func FuzzInserterMetadata(f *testing.F) {
 		1, 128, 0,
 		0, 0, 3,
 	})
+	// A /28 inserted into a /24 record: the split chain reports an existing
+	// depth that is neither the inserted depth nor a record boundary.
+	f.Add([]byte{
+		0, 0, 0,
+		4, 0, 0,
+	})
+	// A /24 failing over two existing /32s: the error fires on the first
+	// covered record.
+	f.Add([]byte{
+		8, 0, 0,
+		8, 1, 0,
+		0, 0, 2,
+	})
+	// A /31 inserted into a /24 record, so the split chain descends seven
+	// levels before it resolves.
+	f.Add([]byte{
+		0, 0, 0,
+		7, 0, 0,
+	})
 
 	f.Fuzz(func(t *testing.T, data []byte) {
 		const bytesPerOperation = 3

--- a/metadata_test.go
+++ b/metadata_test.go
@@ -93,7 +93,9 @@ func TestInserterMetadataCurrentTreeShape(t *testing.T) {
 		require.NoError(t, tree.InsertFunc(
 			netip.MustParsePrefix("1.2.3.0/25"),
 			base.Copy(),
-			inserter.Replace,
+			func(_, newValue mmdbtype.DataType, _ inserter.Metadata) (mmdbtype.DataType, error) {
+				return newValue, nil
+			},
 		))
 
 		var calls []metadataCall
@@ -303,10 +305,7 @@ func TestInserterMetadataNarrowerRecordNetworkFallback(t *testing.T) {
 	require.NoError(t, tree.InsertFunc(
 		netip.MustParsePrefix("1.2.3.0/24"),
 		mmdbtype.String("overlay"),
-		func(existingValue, _ mmdbtype.DataType, metadata inserter.Metadata) (mmdbtype.DataType, error) {
-			calls = append(calls, metadataCall{existing: existingValue, metadata: metadata})
-			return existingValue, nil
-		},
+		captureExisting(&calls),
 	))
 
 	require.Len(t, calls, len(expectedNetworks))
@@ -326,10 +325,7 @@ func TestInserterMetadataFamilyFollowsInsert(t *testing.T) {
 	require.NoError(t, tree.InsertFunc(
 		sharedRecord,
 		mmdbtype.String("v6"),
-		func(existingValue, _ mmdbtype.DataType, metadata inserter.Metadata) (mmdbtype.DataType, error) {
-			v6Calls = append(v6Calls, metadataCall{existing: existingValue, metadata: metadata})
-			return existingValue, nil
-		},
+		captureExisting(&v6Calls),
 	))
 	require.Len(t, v6Calls, 1)
 	assert.Equal(t, sharedRecord, v6Calls[0].metadata.ExistingNetwork())
@@ -338,10 +334,7 @@ func TestInserterMetadataFamilyFollowsInsert(t *testing.T) {
 	require.NoError(t, tree.InsertFunc(
 		netip.MustParsePrefix("1.2.3.4/32"),
 		mmdbtype.String("v4"),
-		func(existingValue, _ mmdbtype.DataType, metadata inserter.Metadata) (mmdbtype.DataType, error) {
-			v4Calls = append(v4Calls, metadataCall{existing: existingValue, metadata: metadata})
-			return existingValue, nil
-		},
+		captureExisting(&v4Calls),
 	))
 	require.Len(t, v4Calls, 1)
 	assert.Equal(t, netip.MustParsePrefix("1.2.3.4/32"), v4Calls[0].metadata.ExistingNetwork())
@@ -352,10 +345,7 @@ func TestInserterMetadataFamilyFollowsInsert(t *testing.T) {
 	require.NoError(t, tree.InsertFunc(
 		netip.MustParsePrefix("::/0"),
 		mmdbtype.String("overlay"),
-		func(existingValue, _ mmdbtype.DataType, metadata inserter.Metadata) (mmdbtype.DataType, error) {
-			allCalls = append(allCalls, metadataCall{existing: existingValue, metadata: metadata})
-			return existingValue, nil
-		},
+		captureExisting(&allCalls),
 	))
 	index := slices.IndexFunc(allCalls, func(call metadataCall) bool {
 		return call.existing == mmdbtype.String("v4-subtree")
@@ -419,120 +409,51 @@ func TestInserterMetadataNormalizesInsertedNetwork(t *testing.T) {
 	}
 }
 
-func TestPureInserterMetadataIsZero(t *testing.T) {
-	assertZero := func(t *testing.T, metadata inserter.Metadata) {
-		t.Helper()
-		assert.Equal(t, netip.Prefix{}, metadata.InsertedNetwork)
-		assert.Zero(t, metadata.ExistingDepth)
-		assert.Equal(t, [16]byte{}, metadata.ExistingAddr)
-		assert.Zero(t, metadata.TreeDepth)
-		assert.Equal(t, netip.Prefix{}, metadata.ExistingNetwork())
-		assert.Zero(t, metadata.InsertedDepth())
+func TestOptionsInserterMemoizesRepeatedValues(t *testing.T) {
+	calls := map[mmdbtype.String]int{}
+	tree := newMetadataTree(t, Options{
+		IPVersion: 4,
+		Inserter: func(existingValue, newValue mmdbtype.DataType) (mmdbtype.DataType, error) {
+			if existingValue != nil {
+				calls[existingValue.(mmdbtype.String)]++
+			}
+			return newValue, nil
+		},
+	})
+	for index, value := range []mmdbtype.String{"a", "b", "a", "b"} {
+		//nolint:gosec // index is bounded by the four-element literal
+		prefix := netip.PrefixFrom(netip.AddrFrom4([4]byte{1, 2, 3, byte(index * 64)}), 26)
+		require.NoError(t, tree.Insert(prefix, value))
 	}
+	clear(calls)
 
-	t.Run("prefix", func(t *testing.T) {
-		tree := newMetadataTree(t, Options{IPVersion: 4})
-		calls := 0
-		require.NoError(t, tree.InsertPureFunc(
-			netip.MustParsePrefix("1.2.3.0/24"),
-			mmdbtype.String("value"),
-			func(_, newValue mmdbtype.DataType, metadata inserter.Metadata) (mmdbtype.DataType, error) {
-				calls++
-				assertZero(t, metadata)
-				return newValue, nil
-			},
-		))
-		assert.Equal(t, 1, calls)
-	})
-
-	t.Run("range memo", func(t *testing.T) {
-		tree := newMetadataTree(t, Options{IPVersion: 4})
-		require.NoError(t, tree.Insert(
-			netip.MustParsePrefix("1.2.3.0/24"),
-			mmdbtype.String("existing"),
-		))
-		calls := 0
-		require.NoError(t, tree.InsertRangePureFunc(
-			netip.MustParseAddr("1.2.3.1"),
-			netip.MustParseAddr("1.2.3.6"),
-			mmdbtype.String("new"),
-			func(_, newValue mmdbtype.DataType, metadata inserter.Metadata) (mmdbtype.DataType, error) {
-				calls++
-				assertZero(t, metadata)
-				return newValue, nil
-			},
-		))
-		assert.Equal(t, 1, calls, "the pure result was not shared across range subnets")
-	})
+	require.NoError(t, tree.Insert(
+		netip.MustParsePrefix("1.2.3.0/24"),
+		mmdbtype.String("new"),
+	))
+	assert.Equal(t, map[mmdbtype.String]int{"a": 1, "b": 1}, calls)
 }
 
-func TestOptionsInserterReceivesMetadata(t *testing.T) {
-	var calls []metadataCall
+func TestOptionsInserterMemoizesAcrossRangeSubnets(t *testing.T) {
+	calls := 0
 	tree := newMetadataTree(t, Options{
 		IPVersion: 4,
-		Inserter:  captureMetadata(&calls),
+		Inserter: func(_, newValue mmdbtype.DataType) (mmdbtype.DataType, error) {
+			calls++
+			return newValue, nil
+		},
 	})
-	prefix := netip.MustParsePrefix("1.2.3.0/24")
-	require.NoError(t, tree.Insert(prefix, mmdbtype.String("value")))
-	require.Len(t, calls, 1)
-	assertMetadata(t, calls[0].metadata, prefix.String(), "0.0.0.0/1", 1, 32)
-}
-
-func TestLoadInserterReceivesMetadata(t *testing.T) {
-	source := newMetadataTree(t, Options{IPVersion: 4})
-	prefix := netip.MustParsePrefix("1.2.3.0/24")
-	require.NoError(t, source.Insert(prefix, mmdbtype.String("value")))
-	path := writeTempDB(t, source)
-
-	var calls []metadataCall
-	loaded, err := Load(path, Options{
-		BuildEpoch:              1,
-		IPVersion:               4,
-		IncludeReservedNetworks: true,
-		Inserter:                captureMetadata(&calls),
-	})
-	require.NoError(t, err)
-	require.Len(t, calls, 1)
-	assertMetadata(t, calls[0].metadata, prefix.String(), "0.0.0.0/1", 1, 32)
-	assert.Equal(
-		t,
-		treeAddr(netip.MustParsePrefix("0.0.0.0/1"), 32),
-		calls[0].metadata.ExistingAddr,
-	)
-	gotPrefix, gotValue := loaded.Get(netip.MustParseAddr("1.2.3.4"))
-	assert.Equal(t, prefix, gotPrefix)
-	assert.Equal(t, mmdbtype.String("value"), gotValue)
-}
-
-func TestOptionsInserterReceivesRangeSubnetMetadata(t *testing.T) {
-	var calls []metadataCall
-	tree := newMetadataTree(t, Options{
-		IPVersion: 4,
-		Inserter:  captureMetadata(&calls),
-	})
+	require.NoError(t, tree.Insert(
+		netip.MustParsePrefix("1.2.3.0/24"),
+		mmdbtype.String("existing"),
+	))
+	calls = 0
 	require.NoError(t, tree.InsertRange(
 		netip.MustParseAddr("1.2.3.1"),
-		netip.MustParseAddr("1.2.3.6"),
-		mmdbtype.String("value"),
+		netip.MustParseAddr("1.2.3.254"),
+		mmdbtype.String("new"),
 	))
-
-	expected := []netip.Prefix{
-		netip.MustParsePrefix("1.2.3.1/32"),
-		netip.MustParsePrefix("1.2.3.2/31"),
-		netip.MustParsePrefix("1.2.3.4/31"),
-		netip.MustParsePrefix("1.2.3.6/32"),
-	}
-	require.Len(t, calls, len(expected))
-	for index, prefix := range expected {
-		metadata := calls[index].metadata
-		assert.Equal(t, prefix, metadata.InsertedNetwork)
-		assert.Equal(t, prefix.Bits(), metadata.InsertedDepth())
-		existingNetwork := metadata.ExistingNetwork()
-		assert.NotEqual(t, netip.Prefix{}, existingNetwork)
-		assert.Equal(t, existingNetwork.Bits(), metadata.ExistingDepth)
-		assert.Equal(t, treeAddr(existingNetwork, 32), metadata.ExistingAddr)
-		assert.Equal(t, 32, metadata.TreeDepth)
-	}
+	assert.Equal(t, 1, calls, "the configured pure result was not shared across range subnets")
 }
 
 func TestFailedInserterRetryMetadata(t *testing.T) {
@@ -582,16 +503,7 @@ func TestFailedInserterRetryMetadata(t *testing.T) {
 			require.ErrorIs(t, err, insertErr)
 
 			var retryCalls []metadataCall
-			require.NoError(t, method.insert(tree, func(
-				existingValue, _ mmdbtype.DataType,
-				metadata inserter.Metadata,
-			) (mmdbtype.DataType, error) {
-				retryCalls = append(
-					retryCalls,
-					metadataCall{existing: existingValue, metadata: metadata},
-				)
-				return existingValue, nil
-			}))
+			require.NoError(t, method.insert(tree, captureExisting(&retryCalls)))
 			require.Len(t, retryCalls, 1)
 			assert.Equal(t, failedMetadata.ExistingDepth, retryCalls[0].metadata.ExistingDepth)
 			assert.Equal(t, failedMetadata.ExistingAddr, retryCalls[0].metadata.ExistingAddr)
@@ -630,16 +542,7 @@ func TestFailedInserterRetryMetadata(t *testing.T) {
 			assert.Equal(t, 2, calls)
 
 			var retryCalls []metadataCall
-			require.NoError(t, method.insert(tree, func(
-				existingValue, _ mmdbtype.DataType,
-				metadata inserter.Metadata,
-			) (mmdbtype.DataType, error) {
-				retryCalls = append(
-					retryCalls,
-					metadataCall{existing: existingValue, metadata: metadata},
-				)
-				return existingValue, nil
-			}))
+			require.NoError(t, method.insert(tree, captureExisting(&retryCalls)))
 			require.Len(t, retryCalls, 1)
 			assert.Equal(t, 24, retryCalls[0].metadata.ExistingDepth)
 			assert.Equal(t, mmdbtype.String("right"), retryCalls[0].existing)
@@ -647,7 +550,7 @@ func TestFailedInserterRetryMetadata(t *testing.T) {
 	}
 }
 
-func TestLoadMetadataDuringCoalescing(t *testing.T) {
+func TestLoadUsesPureOptionsInserter(t *testing.T) {
 	prefixes := []netip.Prefix{
 		netip.MustParsePrefix("1.2.3.0/25"),
 		netip.MustParsePrefix("1.2.3.128/25"),
@@ -655,30 +558,18 @@ func TestLoadMetadataDuringCoalescing(t *testing.T) {
 	value := provenanceValue("equal", 25)
 	sourcePath := writeAdjacentEqualSource(t, prefixes[0], value)
 
-	shadow := newMetadataTree(t, Options{IPVersion: 4})
-	expectedExisting := make([]netip.Prefix, 0, len(prefixes))
-	for _, prefix := range prefixes {
-		existingNetwork, _ := shadow.Get(prefix.Addr())
-		expectedExisting = append(expectedExisting, existingNetwork)
-		require.NoError(t, shadow.Insert(prefix, value))
-	}
-
-	var calls []metadataCall
+	calls := 0
 	loaded, err := Load(sourcePath, Options{
 		BuildEpoch:              1,
 		IPVersion:               4,
 		IncludeReservedNetworks: true,
-		Inserter:                captureMetadata(&calls),
+		Inserter: func(_, newValue mmdbtype.DataType) (mmdbtype.DataType, error) {
+			calls++
+			return newValue, nil
+		},
 	})
 	require.NoError(t, err)
-	require.Len(t, calls, len(prefixes))
-	for index, prefix := range prefixes {
-		metadata := calls[index].metadata
-		assert.Equal(t, prefix, metadata.InsertedNetwork)
-		assert.Equal(t, expectedExisting[index], metadata.ExistingNetwork())
-		assert.Equal(t, expectedExisting[index].Bits(), metadata.ExistingDepth)
-		assert.Equal(t, treeAddr(expectedExisting[index], 32), metadata.ExistingAddr)
-	}
+	assert.Equal(t, len(prefixes), calls)
 
 	physicalPrefix, got := loaded.Get(netip.MustParseAddr("1.2.3.4"))
 	assert.Equal(t, netip.MustParsePrefix("1.2.3.0/24"), physicalPrefix)
@@ -908,12 +799,9 @@ func metadataOracleRecords(
 	require.True(t, insertedNetwork.Addr().Is4())
 	require.GreaterOrEqual(t, insertedNetwork.Bits(), 24)
 	require.LessOrEqual(t, insertedNetwork.Bits(), 32)
-	start := ipv4Uint32(insertedNetwork.Addr())
-	addressCount := uint32(1) << (32 - insertedNetwork.Bits())
-	records := make([]metadataCall, 0, addressCount)
+	records := make([]metadataCall, 0, insertedNetwork.Addr().BitLen())
 	var previous netip.Prefix
-	for offset := range addressCount {
-		address := ipv4Addr(start + offset)
+	for address := insertedNetwork.Addr(); insertedNetwork.Contains(address); address = address.Next() {
 		existingNetwork, existingValue := tree.Get(address)
 		if existingNetwork == previous {
 			continue
@@ -932,11 +820,6 @@ func metadataOracleRecords(
 		}
 	}
 	return records
-}
-
-func ipv4Uint32(address netip.Addr) uint32 {
-	as4 := address.As4()
-	return binary.BigEndian.Uint32(as4[:])
 }
 
 func ipv4Addr(value uint32) netip.Addr {
@@ -979,9 +862,9 @@ func provenanceSpecificityInserter(
 	return newValue, nil
 }
 
-func stripProvenance(t *testing.T, tree *Tree) {
-	t.Helper()
-	require.NoError(t, tree.InsertFunc(
+func stripProvenance(tb testing.TB, tree *Tree) {
+	tb.Helper()
+	require.NoError(tb, tree.InsertFunc(
 		netip.MustParsePrefix("0.0.0.0/0"),
 		nil,
 		func(existingValue, _ mmdbtype.DataType, _ inserter.Metadata) (mmdbtype.DataType, error) {
@@ -1009,14 +892,14 @@ func verifyLoadedProvenanceExtents(
 	}
 }
 
-func loadMetadataFixture(t *testing.T, path string) *Tree {
-	t.Helper()
+func loadMetadataFixture(tb testing.TB, path string) *Tree {
+	tb.Helper()
 	tree, err := Load(path, Options{
 		BuildEpoch:              1,
 		IPVersion:               4,
 		IncludeReservedNetworks: true,
 	})
-	require.NoError(t, err)
+	require.NoError(tb, err)
 	return tree
 }
 
@@ -1067,11 +950,11 @@ func nextPrefixAddr(t *testing.T, prefix netip.Prefix) netip.Addr {
 	return next
 }
 
-func writeTreeBytes(t *testing.T, tree *Tree) []byte {
-	t.Helper()
+func writeTreeBytes(tb testing.TB, tree *Tree) []byte {
+	tb.Helper()
 	var output bytes.Buffer
 	_, err := tree.WriteTo(&output)
-	require.NoError(t, err)
+	require.NoError(tb, err)
 	return output.Bytes()
 }
 
@@ -1096,6 +979,16 @@ func captureMetadata(calls *[]metadataCall) inserter.Func {
 	) (mmdbtype.DataType, error) {
 		*calls = append(*calls, metadataCall{existing: existingValue, metadata: metadata})
 		return newValue, nil
+	}
+}
+
+func captureExisting(calls *[]metadataCall) inserter.Func {
+	return func(
+		existingValue, _ mmdbtype.DataType,
+		metadata inserter.Metadata,
+	) (mmdbtype.DataType, error) {
+		*calls = append(*calls, metadataCall{existing: existingValue, metadata: metadata})
+		return existingValue, nil
 	}
 }
 

--- a/metadata_test.go
+++ b/metadata_test.go
@@ -1,0 +1,1124 @@
+package mmdbwriter
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"net/netip"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go4.org/netipx"
+
+	"github.com/maxmind/mmdbwriter/v2/inserter"
+	"github.com/maxmind/mmdbwriter/v2/mmdbtype"
+)
+
+type metadataCall struct {
+	existing mmdbtype.DataType
+	metadata inserter.Metadata
+}
+
+func TestInserterMetadataRecordShapes(t *testing.T) {
+	t.Run("wider existing record", func(t *testing.T) {
+		tree := newMetadataTree(t, Options{IPVersion: 4})
+		recordValue := mmdbtype.String("existing")
+		require.NoError(t, tree.Insert(netip.MustParsePrefix("1.2.3.0/24"), recordValue))
+
+		var calls []metadataCall
+		require.NoError(t, tree.InsertFunc(
+			netip.MustParsePrefix("1.2.3.0/25"),
+			mmdbtype.String("new"),
+			captureMetadata(&calls),
+		))
+
+		require.Len(t, calls, 1)
+		assert.Equal(t, recordValue, calls[0].existing)
+		assertMetadata(t, calls[0].metadata, "1.2.3.0/25", "1.2.3.0/24", 24, 32)
+		assert.Equal(t, [16]byte{1, 2, 3}, calls[0].metadata.ExistingAddr)
+	})
+
+	t.Run("narrower existing records", func(t *testing.T) {
+		tree := newMetadataTree(t, Options{IPVersion: 4})
+		for index, network := range []string{
+			"1.2.3.0/26",
+			"1.2.3.64/26",
+			"1.2.3.128/25",
+		} {
+			require.NoError(t, tree.Insert(
+				netip.MustParsePrefix(network),
+				mmdbtype.Uint32(index+1),
+			))
+		}
+
+		var calls []metadataCall
+		require.NoError(t, tree.InsertFunc(
+			netip.MustParsePrefix("1.2.3.0/24"),
+			mmdbtype.String("overlay"),
+			captureMetadata(&calls),
+		))
+
+		require.Len(t, calls, 3)
+		for index, expected := range []struct {
+			network string
+			depth   int
+		}{
+			{network: "1.2.3.0/26", depth: 26},
+			{network: "1.2.3.64/26", depth: 26},
+			{network: "1.2.3.128/25", depth: 25},
+		} {
+			assertMetadata(
+				t,
+				calls[index].metadata,
+				"1.2.3.0/24",
+				expected.network,
+				expected.depth,
+				32,
+			)
+		}
+	})
+
+	t.Run("exact existing record", func(t *testing.T) {
+		tree := newMetadataTree(t, Options{IPVersion: 4})
+		prefix := netip.MustParsePrefix("1.2.3.0/24")
+		require.NoError(t, tree.Insert(prefix, mmdbtype.String("existing")))
+
+		var calls []metadataCall
+		require.NoError(t, tree.InsertFunc(prefix, mmdbtype.String("new"), captureMetadata(&calls)))
+
+		require.Len(t, calls, 1)
+		assert.Equal(t, calls[0].metadata.InsertedDepth(), calls[0].metadata.ExistingDepth)
+		assertMetadata(t, calls[0].metadata, prefix.String(), prefix.String(), 24, 32)
+	})
+}
+
+func TestInserterMetadataCurrentTreeShape(t *testing.T) {
+	t.Run("wire equal result remerges", func(t *testing.T) {
+		tree := newMetadataTree(t, Options{IPVersion: 4})
+		base := mmdbtype.Map{"name": mmdbtype.String("same")}
+		require.NoError(t, tree.Insert(netip.MustParsePrefix("1.2.3.0/24"), base))
+		require.NoError(t, tree.InsertFunc(
+			netip.MustParsePrefix("1.2.3.0/25"),
+			base.Copy(),
+			inserter.Replace,
+		))
+
+		var calls []metadataCall
+		require.NoError(t, tree.InsertFunc(
+			netip.MustParsePrefix("1.2.3.0/24"),
+			mmdbtype.String("overlay"),
+			captureMetadata(&calls),
+		))
+		require.Len(t, calls, 1)
+		assert.Equal(t, 24, calls[0].metadata.ExistingDepth)
+	})
+
+	t.Run("earlier insert fragments record", func(t *testing.T) {
+		tree := newMetadataTree(t, Options{IPVersion: 4})
+		require.NoError(t, tree.Insert(
+			netip.MustParsePrefix("1.2.3.0/24"),
+			mmdbtype.String("base"),
+		))
+		require.NoError(t, tree.Insert(
+			netip.MustParsePrefix("1.2.3.0/25"),
+			mmdbtype.String("left"),
+		))
+
+		var calls []metadataCall
+		require.NoError(t, tree.InsertFunc(
+			netip.MustParsePrefix("1.2.3.0/24"),
+			mmdbtype.String("overlay"),
+			captureMetadata(&calls),
+		))
+		require.Len(t, calls, 2)
+		assert.Equal(t, 25, calls[0].metadata.ExistingDepth)
+		assert.Equal(t, 25, calls[1].metadata.ExistingDepth)
+	})
+
+	t.Run("heterogeneous history coalesces", func(t *testing.T) {
+		tree := newMetadataTree(t, Options{IPVersion: 4})
+		base := mmdbtype.String("base")
+		require.NoError(t, tree.Insert(netip.MustParsePrefix("1.2.0.0/16"), base))
+		require.NoError(t, tree.Insert(
+			netip.MustParsePrefix("1.2.0.0/17"),
+			mmdbtype.String("temporary"),
+		))
+		require.NoError(t, tree.Insert(netip.MustParsePrefix("1.2.0.0/17"), base))
+
+		var calls []metadataCall
+		require.NoError(t, tree.InsertFunc(
+			netip.MustParsePrefix("1.2.0.0/16"),
+			mmdbtype.String("overlay"),
+			captureMetadata(&calls),
+		))
+		require.Len(t, calls, 1)
+		assert.Equal(t, 16, calls[0].metadata.ExistingDepth)
+	})
+}
+
+func TestInserterMetadataEmptyRecords(t *testing.T) {
+	t.Run("fresh tree", func(t *testing.T) {
+		tree := newMetadataTree(t, Options{IPVersion: 4})
+		var calls []metadataCall
+		require.NoError(t, tree.InsertFunc(
+			netip.MustParsePrefix("1.2.3.0/24"),
+			mmdbtype.String("new"),
+			captureMetadata(&calls),
+		))
+		require.Len(t, calls, 1)
+		assert.Nil(t, calls[0].existing)
+		assertMetadata(t, calls[0].metadata, "1.2.3.0/24", "0.0.0.0/1", 1, 32)
+	})
+
+	t.Run("previously split empty region", func(t *testing.T) {
+		tree := newMetadataTree(t, Options{IPVersion: 4})
+		require.NoError(t, tree.Insert(
+			netip.MustParsePrefix("1.2.2.0/24"),
+			mmdbtype.String("neighbor"),
+		))
+		expectedNetwork, expectedValue := tree.Get(netip.MustParseAddr("1.2.3.0"))
+		require.Nil(t, expectedValue)
+
+		var calls []metadataCall
+		require.NoError(t, tree.InsertFunc(
+			netip.MustParsePrefix("1.2.3.0/24"),
+			mmdbtype.String("new"),
+			captureMetadata(&calls),
+		))
+		require.Len(t, calls, 1)
+		assert.Nil(t, calls[0].existing)
+		assert.Equal(t, expectedNetwork, calls[0].metadata.ExistingNetwork())
+		assert.Equal(t, expectedNetwork.Bits(), calls[0].metadata.ExistingDepth)
+	})
+
+	t.Run("removal", func(t *testing.T) {
+		tree := newMetadataTree(t, Options{IPVersion: 4})
+		prefix := netip.MustParsePrefix("1.2.3.0/24")
+		require.NoError(t, tree.Insert(prefix, mmdbtype.String("existing")))
+		var calls []metadataCall
+		require.NoError(t, tree.InsertFunc(prefix, nil, func(
+			existingValue, _ mmdbtype.DataType,
+			metadata inserter.Metadata,
+		) (mmdbtype.DataType, error) {
+			calls = append(calls, metadataCall{existing: existingValue, metadata: metadata})
+			return nil, nil
+		}))
+		require.Len(t, calls, 1)
+		assert.Equal(t, mmdbtype.String("existing"), calls[0].existing)
+		assert.Equal(t, prefix, calls[0].metadata.ExistingNetwork())
+	})
+}
+
+func TestInserterMetadataRangeSubnets(t *testing.T) {
+	expectedPrefixes := []netip.Prefix{
+		netip.MustParsePrefix("1.2.3.1/32"),
+		netip.MustParsePrefix("1.2.3.2/31"),
+		netip.MustParsePrefix("1.2.3.4/31"),
+		netip.MustParsePrefix("1.2.3.6/32"),
+	}
+	shadow := newMetadataTree(t, Options{IPVersion: 4})
+	expectedExisting := make([]netip.Prefix, 0, len(expectedPrefixes))
+	for _, prefix := range expectedPrefixes {
+		existingNetwork, _ := shadow.Get(prefix.Addr())
+		expectedExisting = append(expectedExisting, existingNetwork)
+		require.NoError(t, shadow.Insert(prefix, mmdbtype.String(prefix.String())))
+	}
+
+	tree := newMetadataTree(t, Options{IPVersion: 4})
+	var calls []metadataCall
+	require.NoError(t, tree.InsertRangeFunc(
+		netip.MustParseAddr("1.2.3.1"),
+		netip.MustParseAddr("1.2.3.6"),
+		mmdbtype.String("range"),
+		captureMetadata(&calls),
+	))
+
+	require.Len(t, calls, len(expectedPrefixes))
+	for index, prefix := range expectedPrefixes {
+		metadata := calls[index].metadata
+		assert.Equal(t, prefix, metadata.InsertedNetwork)
+		assert.Equal(t, prefix.Bits(), metadata.InsertedDepth())
+		assert.Equal(t, expectedExisting[index], metadata.ExistingNetwork())
+		assert.Equal(t, expectedExisting[index].Bits(), metadata.ExistingDepth)
+		assert.Equal(t, treeAddr(expectedExisting[index], 32), metadata.ExistingAddr)
+		assert.Equal(t, 32, metadata.TreeDepth)
+	}
+}
+
+func TestInserterMetadataIPv4InIPv6Tree(t *testing.T) {
+	tree := newMetadataTree(t, Options{IPVersion: 6})
+	require.NoError(t, tree.Insert(
+		netip.MustParsePrefix("1.0.0.0/8"),
+		mmdbtype.String("existing"),
+	))
+	var calls []metadataCall
+	require.NoError(t, tree.InsertFunc(
+		netip.MustParsePrefix("1.0.0.0/16"),
+		mmdbtype.String("new"),
+		captureMetadata(&calls),
+	))
+
+	require.Len(t, calls, 1)
+	assertMetadata(t, calls[0].metadata, "1.0.0.0/16", "1.0.0.0/8", 104, 128)
+	assert.Equal(t, 112, calls[0].metadata.InsertedDepth())
+	assert.Equal(t, 8, calls[0].metadata.ExistingNetwork().Bits())
+	assert.Equal(
+		t,
+		treeAddr(netip.MustParsePrefix("1.0.0.0/8"), 128),
+		calls[0].metadata.ExistingAddr,
+	)
+	assert.Equal(t, byte(1), calls[0].metadata.ExistingAddr[12])
+	assert.Equal(t, [12]byte{}, [12]byte(calls[0].metadata.ExistingAddr[:12]))
+}
+
+func TestInserterMetadataUnaliasedIPv6ShallowRecord(t *testing.T) {
+	tree := newMetadataTree(t, Options{
+		DisableIPv4Aliasing: true,
+		IPVersion:           6,
+	})
+	var calls []metadataCall
+	require.NoError(t, tree.InsertFunc(
+		netip.MustParsePrefix("1.2.3.0/24"),
+		mmdbtype.String("new"),
+		captureMetadata(&calls),
+	))
+
+	require.Len(t, calls, 1)
+	assert.Nil(t, calls[0].existing)
+	assertMetadata(t, calls[0].metadata, "1.2.3.0/24", "::/1", 1, 128)
+	assert.Equal(t, 120, calls[0].metadata.InsertedDepth())
+}
+
+func TestInserterMetadataAddressCopyAndSiblingTracking(t *testing.T) {
+	tree := newMetadataTree(t, Options{IPVersion: 4})
+	expectedNetworks := []netip.Prefix{
+		netip.MustParsePrefix("1.2.3.0/26"),
+		netip.MustParsePrefix("1.2.3.64/26"),
+		netip.MustParsePrefix("1.2.3.128/26"),
+		netip.MustParsePrefix("1.2.3.192/26"),
+	}
+	for index, prefix := range expectedNetworks {
+		require.NoError(t, tree.Insert(prefix, mmdbtype.Uint32(index)))
+	}
+
+	var calls []metadataCall
+	require.NoError(t, tree.InsertFunc(
+		netip.MustParsePrefix("1.2.3.0/24"),
+		mmdbtype.String("overlay"),
+		func(existingValue, _ mmdbtype.DataType, metadata inserter.Metadata) (mmdbtype.DataType, error) {
+			calls = append(calls, metadataCall{existing: existingValue, metadata: metadata})
+			return existingValue, nil
+		},
+	))
+
+	require.Len(t, calls, len(expectedNetworks))
+	for index, expected := range expectedNetworks {
+		assert.Equal(t, expected, calls[index].metadata.ExistingNetwork())
+		assert.Equal(t, expected.Addr().As4(), [4]byte(calls[index].metadata.ExistingAddr[:4]))
+	}
+}
+
+func TestInserterMetadataFamilyFollowsInsert(t *testing.T) {
+	tree := newMetadataTree(t, Options{IPVersion: 6})
+	sharedRecord := netip.MustParsePrefix("::102:304/128")
+	require.NoError(t, tree.Insert(sharedRecord, mmdbtype.String("shared")))
+
+	var v6Calls []metadataCall
+	require.NoError(t, tree.InsertFunc(
+		sharedRecord,
+		mmdbtype.String("v6"),
+		func(existingValue, _ mmdbtype.DataType, metadata inserter.Metadata) (mmdbtype.DataType, error) {
+			v6Calls = append(v6Calls, metadataCall{existing: existingValue, metadata: metadata})
+			return existingValue, nil
+		},
+	))
+	require.Len(t, v6Calls, 1)
+	assert.Equal(t, sharedRecord, v6Calls[0].metadata.ExistingNetwork())
+
+	var v4Calls []metadataCall
+	require.NoError(t, tree.InsertFunc(
+		netip.MustParsePrefix("1.2.3.4/32"),
+		mmdbtype.String("v4"),
+		func(existingValue, _ mmdbtype.DataType, metadata inserter.Metadata) (mmdbtype.DataType, error) {
+			v4Calls = append(v4Calls, metadataCall{existing: existingValue, metadata: metadata})
+			return existingValue, nil
+		},
+	))
+	require.Len(t, v4Calls, 1)
+	assert.Equal(t, netip.MustParsePrefix("1.2.3.4/32"), v4Calls[0].metadata.ExistingNetwork())
+
+	v4Prefix := netip.MustParsePrefix("1.0.0.0/4")
+	require.NoError(t, tree.Insert(v4Prefix, mmdbtype.String("v4-subtree")))
+	var allCalls []metadataCall
+	require.NoError(t, tree.InsertFunc(
+		netip.MustParsePrefix("::/0"),
+		mmdbtype.String("overlay"),
+		func(existingValue, _ mmdbtype.DataType, metadata inserter.Metadata) (mmdbtype.DataType, error) {
+			allCalls = append(allCalls, metadataCall{existing: existingValue, metadata: metadata})
+			return existingValue, nil
+		},
+	))
+	index := slices.IndexFunc(allCalls, func(call metadataCall) bool {
+		return call.existing == mmdbtype.String("v4-subtree")
+	})
+	require.NotEqual(t, -1, index)
+	assert.Equal(t, 100, allCalls[index].metadata.ExistingDepth)
+	assert.Equal(t, netip.MustParsePrefix("::/100"), allCalls[index].metadata.ExistingNetwork())
+}
+
+func TestInserterMetadataRootInsert(t *testing.T) {
+	tree := newMetadataTree(t, Options{
+		DisableIPv4Aliasing: true,
+		IPVersion:           6,
+	})
+	var calls []metadataCall
+	require.NoError(t, tree.InsertFunc(
+		netip.MustParsePrefix("::/0"),
+		mmdbtype.String("root"),
+		captureMetadata(&calls),
+	))
+	require.Len(t, calls, 2)
+	assert.Equal(t, netip.MustParsePrefix("::/1"), calls[0].metadata.ExistingNetwork())
+	assert.Equal(t, netip.MustParsePrefix("8000::/1"), calls[1].metadata.ExistingNetwork())
+}
+
+func TestInserterMetadataNormalizesInsertedNetwork(t *testing.T) {
+	tests := []struct {
+		name     string
+		prefix   netip.Prefix
+		expected netip.Prefix
+	}{
+		{
+			name:     "unmasked",
+			prefix:   netip.PrefixFrom(netip.MustParseAddr("1.2.3.4"), 24),
+			expected: netip.MustParsePrefix("1.2.3.0/24"),
+		},
+		{
+			name:     "IPv4 mapped",
+			prefix:   netip.MustParsePrefix("::ffff:1.2.3.4/120"),
+			expected: netip.MustParsePrefix("1.2.3.0/24"),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			tree := newMetadataTree(t, Options{IPVersion: 4})
+			var calls []metadataCall
+			require.NoError(t, tree.InsertFunc(
+				test.prefix,
+				mmdbtype.String("value"),
+				captureMetadata(&calls),
+			))
+			require.NotEmpty(t, calls)
+			for _, call := range calls {
+				assert.Equal(t, test.expected, call.metadata.InsertedNetwork)
+			}
+		})
+	}
+}
+
+func TestPureInserterMetadataIsZero(t *testing.T) {
+	assertZero := func(t *testing.T, metadata inserter.Metadata) {
+		t.Helper()
+		assert.Equal(t, netip.Prefix{}, metadata.InsertedNetwork)
+		assert.Zero(t, metadata.ExistingDepth)
+		assert.Equal(t, [16]byte{}, metadata.ExistingAddr)
+		assert.Zero(t, metadata.TreeDepth)
+		assert.Equal(t, netip.Prefix{}, metadata.ExistingNetwork())
+		assert.Zero(t, metadata.InsertedDepth())
+	}
+
+	t.Run("prefix", func(t *testing.T) {
+		tree := newMetadataTree(t, Options{IPVersion: 4})
+		calls := 0
+		require.NoError(t, tree.InsertPureFunc(
+			netip.MustParsePrefix("1.2.3.0/24"),
+			mmdbtype.String("value"),
+			func(_, newValue mmdbtype.DataType, metadata inserter.Metadata) (mmdbtype.DataType, error) {
+				calls++
+				assertZero(t, metadata)
+				return newValue, nil
+			},
+		))
+		assert.Equal(t, 1, calls)
+	})
+
+	t.Run("range memo", func(t *testing.T) {
+		tree := newMetadataTree(t, Options{IPVersion: 4})
+		require.NoError(t, tree.Insert(
+			netip.MustParsePrefix("1.2.3.0/24"),
+			mmdbtype.String("existing"),
+		))
+		calls := 0
+		require.NoError(t, tree.InsertRangePureFunc(
+			netip.MustParseAddr("1.2.3.1"),
+			netip.MustParseAddr("1.2.3.6"),
+			mmdbtype.String("new"),
+			func(_, newValue mmdbtype.DataType, metadata inserter.Metadata) (mmdbtype.DataType, error) {
+				calls++
+				assertZero(t, metadata)
+				return newValue, nil
+			},
+		))
+		assert.Equal(t, 1, calls, "the pure result was not shared across range subnets")
+	})
+}
+
+func TestOptionsInserterReceivesMetadata(t *testing.T) {
+	var calls []metadataCall
+	tree := newMetadataTree(t, Options{
+		IPVersion: 4,
+		Inserter:  captureMetadata(&calls),
+	})
+	prefix := netip.MustParsePrefix("1.2.3.0/24")
+	require.NoError(t, tree.Insert(prefix, mmdbtype.String("value")))
+	require.Len(t, calls, 1)
+	assertMetadata(t, calls[0].metadata, prefix.String(), "0.0.0.0/1", 1, 32)
+}
+
+func TestLoadInserterReceivesMetadata(t *testing.T) {
+	source := newMetadataTree(t, Options{IPVersion: 4})
+	prefix := netip.MustParsePrefix("1.2.3.0/24")
+	require.NoError(t, source.Insert(prefix, mmdbtype.String("value")))
+	path := writeTempDB(t, source)
+
+	var calls []metadataCall
+	loaded, err := Load(path, Options{
+		BuildEpoch:              1,
+		IPVersion:               4,
+		IncludeReservedNetworks: true,
+		Inserter:                captureMetadata(&calls),
+	})
+	require.NoError(t, err)
+	require.Len(t, calls, 1)
+	assertMetadata(t, calls[0].metadata, prefix.String(), "0.0.0.0/1", 1, 32)
+	assert.Equal(
+		t,
+		treeAddr(netip.MustParsePrefix("0.0.0.0/1"), 32),
+		calls[0].metadata.ExistingAddr,
+	)
+	gotPrefix, gotValue := loaded.Get(netip.MustParseAddr("1.2.3.4"))
+	assert.Equal(t, prefix, gotPrefix)
+	assert.Equal(t, mmdbtype.String("value"), gotValue)
+}
+
+func TestOptionsInserterReceivesRangeSubnetMetadata(t *testing.T) {
+	var calls []metadataCall
+	tree := newMetadataTree(t, Options{
+		IPVersion: 4,
+		Inserter:  captureMetadata(&calls),
+	})
+	require.NoError(t, tree.InsertRange(
+		netip.MustParseAddr("1.2.3.1"),
+		netip.MustParseAddr("1.2.3.6"),
+		mmdbtype.String("value"),
+	))
+
+	expected := []netip.Prefix{
+		netip.MustParsePrefix("1.2.3.1/32"),
+		netip.MustParsePrefix("1.2.3.2/31"),
+		netip.MustParsePrefix("1.2.3.4/31"),
+		netip.MustParsePrefix("1.2.3.6/32"),
+	}
+	require.Len(t, calls, len(expected))
+	for index, prefix := range expected {
+		metadata := calls[index].metadata
+		assert.Equal(t, prefix, metadata.InsertedNetwork)
+		assert.Equal(t, prefix.Bits(), metadata.InsertedDepth())
+		existingNetwork := metadata.ExistingNetwork()
+		assert.NotEqual(t, netip.Prefix{}, existingNetwork)
+		assert.Equal(t, existingNetwork.Bits(), metadata.ExistingDepth)
+		assert.Equal(t, treeAddr(existingNetwork, 32), metadata.ExistingAddr)
+		assert.Equal(t, 32, metadata.TreeDepth)
+	}
+}
+
+func TestFailedInserterRetryMetadata(t *testing.T) {
+	insertMethods := []struct {
+		name   string
+		insert func(*Tree, inserter.Func) error
+	}{
+		{
+			name: "prefix",
+			insert: func(tree *Tree, insertFunc inserter.Func) error {
+				return tree.InsertFunc(
+					netip.MustParsePrefix("1.2.3.0/24"),
+					mmdbtype.String("overlay"),
+					insertFunc,
+				)
+			},
+		},
+		{
+			name: "range",
+			insert: func(tree *Tree, insertFunc inserter.Func) error {
+				return tree.InsertRangeFunc(
+					netip.MustParseAddr("1.2.3.0"),
+					netip.MustParseAddr("1.2.3.255"),
+					mmdbtype.String("overlay"),
+					insertFunc,
+				)
+			},
+		},
+	}
+
+	for _, method := range insertMethods {
+		t.Run(method.name+" no result installed", func(t *testing.T) {
+			tree := newMetadataTree(t, Options{IPVersion: 4})
+			require.NoError(t, tree.Insert(
+				netip.MustParsePrefix("1.2.3.0/23"),
+				mmdbtype.String("base"),
+			))
+			insertErr := errors.New("insert failed")
+			var failedMetadata inserter.Metadata
+			err := method.insert(tree, func(
+				_, _ mmdbtype.DataType,
+				metadata inserter.Metadata,
+			) (mmdbtype.DataType, error) {
+				failedMetadata = metadata
+				return nil, insertErr
+			})
+			require.ErrorIs(t, err, insertErr)
+
+			var retryCalls []metadataCall
+			require.NoError(t, method.insert(tree, func(
+				existingValue, _ mmdbtype.DataType,
+				metadata inserter.Metadata,
+			) (mmdbtype.DataType, error) {
+				retryCalls = append(
+					retryCalls,
+					metadataCall{existing: existingValue, metadata: metadata},
+				)
+				return existingValue, nil
+			}))
+			require.Len(t, retryCalls, 1)
+			assert.Equal(t, failedMetadata.ExistingDepth, retryCalls[0].metadata.ExistingDepth)
+			assert.Equal(t, failedMetadata.ExistingAddr, retryCalls[0].metadata.ExistingAddr)
+			assert.Equal(
+				t,
+				failedMetadata.ExistingNetwork(),
+				retryCalls[0].metadata.ExistingNetwork(),
+			)
+			assert.Equal(t, mmdbtype.String("base"), retryCalls[0].existing)
+		})
+
+		t.Run(method.name+" partial success coalesces", func(t *testing.T) {
+			tree := newMetadataTree(t, Options{IPVersion: 4})
+			require.NoError(t, tree.Insert(
+				netip.MustParsePrefix("1.2.3.0/25"),
+				mmdbtype.String("left"),
+			))
+			require.NoError(t, tree.Insert(
+				netip.MustParsePrefix("1.2.3.128/25"),
+				mmdbtype.String("right"),
+			))
+
+			insertErr := errors.New("insert failed after success")
+			calls := 0
+			err := method.insert(tree, func(
+				_, _ mmdbtype.DataType,
+				_ inserter.Metadata,
+			) (mmdbtype.DataType, error) {
+				calls++
+				if calls == 1 {
+					return mmdbtype.String("right"), nil
+				}
+				return nil, insertErr
+			})
+			require.ErrorIs(t, err, insertErr)
+			assert.Equal(t, 2, calls)
+
+			var retryCalls []metadataCall
+			require.NoError(t, method.insert(tree, func(
+				existingValue, _ mmdbtype.DataType,
+				metadata inserter.Metadata,
+			) (mmdbtype.DataType, error) {
+				retryCalls = append(
+					retryCalls,
+					metadataCall{existing: existingValue, metadata: metadata},
+				)
+				return existingValue, nil
+			}))
+			require.Len(t, retryCalls, 1)
+			assert.Equal(t, 24, retryCalls[0].metadata.ExistingDepth)
+			assert.Equal(t, mmdbtype.String("right"), retryCalls[0].existing)
+		})
+	}
+}
+
+func TestLoadMetadataDuringCoalescing(t *testing.T) {
+	prefixes := []netip.Prefix{
+		netip.MustParsePrefix("1.2.3.0/25"),
+		netip.MustParsePrefix("1.2.3.128/25"),
+	}
+	value := provenanceValue("equal", 25)
+	sourcePath := writeAdjacentEqualSource(t, prefixes[0], value)
+
+	shadow := newMetadataTree(t, Options{IPVersion: 4})
+	expectedExisting := make([]netip.Prefix, 0, len(prefixes))
+	for _, prefix := range prefixes {
+		existingNetwork, _ := shadow.Get(prefix.Addr())
+		expectedExisting = append(expectedExisting, existingNetwork)
+		require.NoError(t, shadow.Insert(prefix, value))
+	}
+
+	var calls []metadataCall
+	loaded, err := Load(sourcePath, Options{
+		BuildEpoch:              1,
+		IPVersion:               4,
+		IncludeReservedNetworks: true,
+		Inserter:                captureMetadata(&calls),
+	})
+	require.NoError(t, err)
+	require.Len(t, calls, len(prefixes))
+	for index, prefix := range prefixes {
+		metadata := calls[index].metadata
+		assert.Equal(t, prefix, metadata.InsertedNetwork)
+		assert.Equal(t, expectedExisting[index], metadata.ExistingNetwork())
+		assert.Equal(t, expectedExisting[index].Bits(), metadata.ExistingDepth)
+		assert.Equal(t, treeAddr(expectedExisting[index], 32), metadata.ExistingAddr)
+	}
+
+	physicalPrefix, got := loaded.Get(netip.MustParseAddr("1.2.3.4"))
+	assert.Equal(t, netip.MustParsePrefix("1.2.3.0/24"), physicalPrefix)
+	assert.Equal(t, value, got)
+}
+
+func TestMetadataLoadThenOverlayMatchesProvenanceWorkflow(t *testing.T) {
+	source := newMetadataTree(t, Options{IPVersion: 4})
+	base := []benchmarkInsertSpec{
+		{
+			network: netip.MustParsePrefix("1.0.0.0/25"),
+			value:   provenanceValue("base-specific-left", 25),
+		},
+		{
+			network: netip.MustParsePrefix("1.0.0.128/25"),
+			value:   provenanceValue("base-specific-right", 25),
+		},
+		{
+			network: netip.MustParsePrefix("2.0.0.0/24"),
+			value:   provenanceValue("base-wide", 24),
+		},
+	}
+	for _, spec := range base {
+		require.NoError(t, source.Insert(spec.network, spec.value))
+	}
+	sourcePath := writeTempDB(t, source)
+
+	verifyLoadedProvenanceExtents(t, sourcePath, base)
+	overlays := []benchmarkInsertSpec{
+		{
+			network: netip.MustParsePrefix("2.0.0.0/25"),
+			value:   provenanceValue("overlay-specific", 25),
+		},
+		{
+			network: netip.MustParsePrefix("1.0.0.0/24"),
+			value:   provenanceValue("overlay-wide", 24),
+		},
+	}
+
+	metadataTree := loadMetadataFixture(t, sourcePath)
+	for _, spec := range overlays {
+		require.NoError(t, metadataTree.InsertFunc(
+			spec.network,
+			spec.value,
+			metadataSpecificityInserter,
+		))
+	}
+
+	provenanceTree := loadMetadataFixture(t, sourcePath)
+	sortedOverlays := slices.Clone(overlays)
+	slices.SortFunc(sortedOverlays, func(left, right benchmarkInsertSpec) int {
+		return right.network.Bits() - left.network.Bits()
+	})
+	for _, spec := range sortedOverlays {
+		require.NoError(t, provenanceTree.InsertFunc(
+			spec.network,
+			spec.value,
+			provenanceSpecificityInserter,
+		))
+	}
+
+	stripProvenance(t, metadataTree)
+	stripProvenance(t, provenanceTree)
+	for _, test := range []struct {
+		address string
+		name    mmdbtype.String
+	}{
+		{address: "1.0.0.1", name: "base-specific-left"},
+		{address: "1.0.0.200", name: "base-specific-right"},
+		{address: "2.0.0.1", name: "overlay-specific"},
+		{address: "2.0.0.200", name: "base-wide"},
+	} {
+		for _, tree := range []*Tree{metadataTree, provenanceTree} {
+			_, value := tree.Get(netip.MustParseAddr(test.address))
+			valueMap := value.(mmdbtype.Map)
+			assert.Equal(t, test.name, valueMap["name"])
+			assert.NotContains(t, valueMap, provenancePrefixLengthKey)
+		}
+	}
+	assert.Equal(t, writeTreeBytes(t, metadataTree), writeTreeBytes(t, provenanceTree))
+}
+
+func TestMetadataSpecificityDiffersFromProvenanceAtDocumentedBoundaries(t *testing.T) {
+	t.Run("load coalesces adjacent equal records", func(t *testing.T) {
+		path := writeAdjacentEqualSource(
+			t,
+			netip.MustParsePrefix("1.2.3.0/25"),
+			provenanceValue("base", 25),
+		)
+		metadataTree := loadMetadataFixture(t, path)
+		provenanceTree := loadMetadataFixture(t, path)
+		overlay := provenanceValue("overlay", 24)
+		prefix := netip.MustParsePrefix("1.2.3.0/24")
+		require.NoError(t, metadataTree.InsertFunc(prefix, overlay, metadataSpecificityInserter))
+		require.NoError(
+			t,
+			provenanceTree.InsertFunc(prefix, overlay, provenanceSpecificityInserter),
+		)
+
+		_, metadataValue := metadataTree.Get(netip.MustParseAddr("1.2.3.4"))
+		_, provenanceResult := provenanceTree.Get(netip.MustParseAddr("1.2.3.4"))
+		assert.Equal(t, mmdbtype.String("overlay"), metadataValue.(mmdbtype.Map)["name"])
+		assert.Equal(t, mmdbtype.String("base"), provenanceResult.(mmdbtype.Map)["name"])
+	})
+
+	t.Run("root remains two records", func(t *testing.T) {
+		source := newMetadataTree(t, Options{IPVersion: 4})
+		require.NoError(t, source.Insert(
+			netip.MustParsePrefix("0.0.0.0/0"),
+			provenanceValue("base", 0),
+		))
+		path := writeTempDB(t, source)
+		metadataTree := loadMetadataFixture(t, path)
+		provenanceTree := loadMetadataFixture(t, path)
+		overlay := provenanceValue("overlay", 0)
+		prefix := netip.MustParsePrefix("0.0.0.0/0")
+		require.NoError(t, metadataTree.InsertFunc(prefix, overlay, metadataSpecificityInserter))
+		require.NoError(
+			t,
+			provenanceTree.InsertFunc(prefix, overlay, provenanceSpecificityInserter),
+		)
+
+		physicalPrefix, metadataValue := metadataTree.Get(netip.MustParseAddr("1.2.3.4"))
+		_, provenanceResult := provenanceTree.Get(netip.MustParseAddr("1.2.3.4"))
+		assert.Equal(t, netip.MustParsePrefix("0.0.0.0/1"), physicalPrefix)
+		assert.Equal(t, mmdbtype.String("base"), metadataValue.(mmdbtype.Map)["name"])
+		assert.Equal(t, mmdbtype.String("overlay"), provenanceResult.(mmdbtype.Map)["name"])
+	})
+}
+
+func FuzzInserterMetadata(f *testing.F) {
+	f.Add([]byte{
+		0, 0, 0,
+		1, 0, 0,
+		0, 0, 0,
+	})
+	f.Add([]byte{
+		0, 0, 0,
+		1, 0, 0,
+		0, 0, 1,
+	})
+	f.Add([]byte{
+		0, 0, 0,
+		1, 0, 2,
+		1, 0, 0,
+	})
+	f.Add([]byte{
+		1, 0, 0,
+		1, 128, 0,
+		0, 0, 3,
+	})
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		const bytesPerOperation = 3
+		const maxOperations = 64
+		operationCount := min(len(data)/bytesPerOperation, maxOperations)
+		if operationCount == 0 {
+			return
+		}
+
+		tree := newMetadataTree(t, Options{IPVersion: 4})
+		for operation := range operationCount {
+			offset := operation * bytesPerOperation
+			prefixLength := 24 + int(data[offset]%9)
+			prefix := netip.PrefixFrom(
+				netip.AddrFrom4([4]byte{1, 2, 3, data[offset+1]}),
+				prefixLength,
+			).Masked()
+			action := data[offset+2] % 4
+			expected := metadataOracleRecords(t, tree, prefix)
+			insertErr := errors.New("fuzz insertion failure")
+			callIndex := 0
+			err := tree.InsertFunc(
+				prefix,
+				mmdbtype.Uint32(operation+1),
+				func(
+					existingValue, newValue mmdbtype.DataType,
+					metadata inserter.Metadata,
+				) (mmdbtype.DataType, error) {
+					require.Less(t, callIndex, len(expected))
+					want := expected[callIndex]
+					assert.Equal(t, want.existing, existingValue)
+					assert.Equal(t, prefix, metadata.InsertedNetwork)
+					assert.Equal(t, prefixLength, metadata.InsertedDepth())
+					assert.Equal(t, want.metadata.ExistingDepth, metadata.ExistingDepth)
+					assert.Equal(t, want.metadata.ExistingAddr, metadata.ExistingAddr)
+					assert.Equal(t, want.metadata.ExistingNetwork(), metadata.ExistingNetwork())
+					assert.Equal(t, 32, metadata.TreeDepth)
+
+					currentCall := callIndex
+					callIndex++
+					switch action {
+					case 0:
+						return newValue, nil
+					case 1:
+						return nil, nil
+					case 2:
+						return nil, insertErr
+					case 3:
+						if currentCall == 1 || len(expected) == 1 {
+							return nil, insertErr
+						}
+						return newValue, nil
+					default:
+						panic("unreachable fuzz action")
+					}
+				},
+			)
+
+			switch action {
+			case 0, 1:
+				require.NoError(t, err)
+				assert.Len(t, expected, callIndex)
+			case 2, 3:
+				require.ErrorIs(t, err, insertErr)
+			}
+		}
+	})
+}
+
+func metadataOracleRecords(
+	t *testing.T,
+	tree *Tree,
+	insertedNetwork netip.Prefix,
+) []metadataCall {
+	t.Helper()
+	require.True(t, insertedNetwork.Addr().Is4())
+	require.GreaterOrEqual(t, insertedNetwork.Bits(), 24)
+	require.LessOrEqual(t, insertedNetwork.Bits(), 32)
+	start := ipv4Uint32(insertedNetwork.Addr())
+	addressCount := uint32(1) << (32 - insertedNetwork.Bits())
+	records := make([]metadataCall, 0, addressCount)
+	var previous netip.Prefix
+	for offset := range addressCount {
+		address := ipv4Addr(start + offset)
+		existingNetwork, existingValue := tree.Get(address)
+		if existingNetwork == previous {
+			continue
+		}
+		previous = existingNetwork
+		records = append(records, metadataCall{
+			existing: existingValue,
+			metadata: inserter.Metadata{
+				InsertedNetwork: insertedNetwork,
+				ExistingDepth:   existingNetwork.Bits(),
+				ExistingAddr:    treeAddr(existingNetwork, 32),
+				TreeDepth:       32,
+			},
+		})
+	}
+	return records
+}
+
+func ipv4Uint32(address netip.Addr) uint32 {
+	as4 := address.As4()
+	return binary.BigEndian.Uint32(as4[:])
+}
+
+func ipv4Addr(value uint32) netip.Addr {
+	var address [4]byte
+	binary.BigEndian.PutUint32(address[:], value)
+	return netip.AddrFrom4(address)
+}
+
+const provenancePrefixLengthKey mmdbtype.String = "_prefix_length"
+
+func provenanceValue(name mmdbtype.String, prefixLength uint16) mmdbtype.Map {
+	return mmdbtype.Map{
+		"name":                    name,
+		provenancePrefixLengthKey: mmdbtype.Uint16(prefixLength),
+	}
+}
+
+func metadataSpecificityInserter(
+	existingValue, newValue mmdbtype.DataType,
+	metadata inserter.Metadata,
+) (mmdbtype.DataType, error) {
+	if existingValue != nil && metadata.ExistingDepth > metadata.InsertedDepth() {
+		return existingValue, nil
+	}
+	return newValue, nil
+}
+
+func provenanceSpecificityInserter(
+	existingValue, newValue mmdbtype.DataType,
+	_ inserter.Metadata,
+) (mmdbtype.DataType, error) {
+	if existingValue == nil {
+		return newValue, nil
+	}
+	existingDepth := existingValue.(mmdbtype.Map)[provenancePrefixLengthKey].(mmdbtype.Uint16)
+	newDepth := newValue.(mmdbtype.Map)[provenancePrefixLengthKey].(mmdbtype.Uint16)
+	if existingDepth > newDepth {
+		return existingValue, nil
+	}
+	return newValue, nil
+}
+
+func stripProvenance(t *testing.T, tree *Tree) {
+	t.Helper()
+	require.NoError(t, tree.InsertFunc(
+		netip.MustParsePrefix("0.0.0.0/0"),
+		nil,
+		func(existingValue, _ mmdbtype.DataType, _ inserter.Metadata) (mmdbtype.DataType, error) {
+			if existingValue == nil {
+				return nil, nil
+			}
+			value := existingValue.Copy().(mmdbtype.Map)
+			delete(value, provenancePrefixLengthKey)
+			return value, nil
+		},
+	))
+}
+
+func verifyLoadedProvenanceExtents(
+	t *testing.T,
+	path string,
+	specs []benchmarkInsertSpec,
+) {
+	t.Helper()
+	tree := loadMetadataFixture(t, path)
+	for _, spec := range specs {
+		physicalPrefix, value := tree.Get(spec.network.Addr())
+		storedDepth := value.(mmdbtype.Map)[provenancePrefixLengthKey].(mmdbtype.Uint16)
+		assert.Equal(t, int(storedDepth), physicalPrefix.Bits())
+	}
+}
+
+func loadMetadataFixture(t *testing.T, path string) *Tree {
+	t.Helper()
+	tree, err := Load(path, Options{
+		BuildEpoch:              1,
+		IPVersion:               4,
+		IncludeReservedNetworks: true,
+	})
+	require.NoError(t, err)
+	return tree
+}
+
+func writeAdjacentEqualSource(
+	t *testing.T,
+	leftPrefix netip.Prefix,
+	value mmdbtype.DataType,
+) string {
+	t.Helper()
+	rightPrefix := netip.PrefixFrom(nextPrefixAddr(t, leftPrefix), leftPrefix.Bits())
+	tree := newMetadataTree(t, Options{IPVersion: 4})
+	require.NoError(t, tree.Insert(leftPrefix, value))
+	require.NoError(t, tree.Insert(rightPrefix, mmdbtype.String("temporary")))
+	tree.expandPaths(tree.root, 0)
+	parentPrefix := netip.PrefixFrom(leftPrefix.Addr(), leftPrefix.Bits()-1).Masked()
+	parent := recordAtPrefix(t, tree, parentPrefix)
+	require.Equal(t, recordTypeNode, parent.recordType)
+	node := tree.nodeAt(parent.nodeIndex)
+	require.Equal(t, recordTypeData, node.children[0].recordType)
+	require.Equal(t, recordTypeData, node.children[1].recordType)
+	tree.valueStore.retain(node.children[0].value)
+	tree.valueStore.release(node.children[1].value)
+	node.children[1].value = node.children[0].value
+	return writeTempDB(t, tree)
+}
+
+func recordAtPrefix(t *testing.T, tree *Tree, prefix netip.Prefix) *record {
+	t.Helper()
+	ip, prefixLength := tree.prefixInsertIP(prefix)
+	currentNodeIndex := tree.root
+	for depth := range prefixLength {
+		currentNode := tree.nodeAt(currentNodeIndex)
+		record := &currentNode.children[bitAt(ip, depth)]
+		if depth+1 == prefixLength {
+			return record
+		}
+		require.Contains(t, []recordType{recordTypeNode, recordTypeFixedNode}, record.recordType)
+		currentNodeIndex = record.nodeIndex
+	}
+	t.Fatal("the root is not represented by a record")
+	return nil
+}
+
+func nextPrefixAddr(t *testing.T, prefix netip.Prefix) netip.Addr {
+	t.Helper()
+	next := netipx.RangeOfPrefix(prefix).To().Next()
+	require.True(t, next.IsValid(), "prefix %s has no following address", prefix)
+	return next
+}
+
+func writeTreeBytes(t *testing.T, tree *Tree) []byte {
+	t.Helper()
+	var output bytes.Buffer
+	_, err := tree.WriteTo(&output)
+	require.NoError(t, err)
+	return output.Bytes()
+}
+
+func treeAddr(prefix netip.Prefix, treeDepth int) [16]byte {
+	var address [16]byte
+	if prefix.Addr().Is4() {
+		as4 := prefix.Addr().As4()
+		if treeDepth == 32 {
+			copy(address[:4], as4[:])
+		} else {
+			copy(address[12:], as4[:])
+		}
+		return address
+	}
+	return prefix.Addr().As16()
+}
+
+func captureMetadata(calls *[]metadataCall) inserter.Func {
+	return func(
+		existingValue, newValue mmdbtype.DataType,
+		metadata inserter.Metadata,
+	) (mmdbtype.DataType, error) {
+		*calls = append(*calls, metadataCall{existing: existingValue, metadata: metadata})
+		return newValue, nil
+	}
+}
+
+func assertMetadata(
+	t *testing.T,
+	metadata inserter.Metadata,
+	inserted,
+	existing string,
+	existingDepth,
+	treeDepth int,
+) {
+	t.Helper()
+	assert.Equal(t, netip.MustParsePrefix(inserted), metadata.InsertedNetwork)
+	assert.Equal(t, netip.MustParsePrefix(existing), metadata.ExistingNetwork())
+	assert.Equal(t, existingDepth, metadata.ExistingDepth)
+	assert.Equal(t, treeDepth, metadata.TreeDepth)
+}
+
+func newMetadataTree(t *testing.T, options Options) *Tree {
+	t.Helper()
+	options.BuildEpoch = 1
+	options.DatabaseType = "inserter-metadata-test"
+	options.Description = map[string]string{"en": "Inserter metadata test"}
+	options.IncludeReservedNetworks = true
+	options.RecordSize = 24
+	tree, err := New(options)
+	require.NoError(t, err)
+	return tree
+}

--- a/metadata_test.go
+++ b/metadata_test.go
@@ -479,6 +479,84 @@ func TestOptionsInserterMemoizesAcrossRangeSubnets(t *testing.T) {
 	assert.Equal(t, 1, calls, "the configured pure result was not shared across range subnets")
 }
 
+func TestFailedInsertRestoresDeepSplitChain(t *testing.T) {
+	tree := newMetadataTree(t, Options{IPVersion: 4})
+	require.NoError(t, tree.Insert(
+		netip.MustParsePrefix("1.0.0.0/8"),
+		mmdbtype.String("base"),
+	))
+	before := writeTreeBytes(t, tree)
+
+	// A /32 inside a /8 record splits 24 levels, so the unwinding merge has to
+	// fire at every frame to put the record back.
+	insertErr := errors.New("insert failed")
+	err := tree.InsertFunc(
+		netip.MustParsePrefix("1.2.3.4/32"),
+		mmdbtype.String("overlay"),
+		func(_, _ mmdbtype.DataType, _ inserter.Metadata) (mmdbtype.DataType, error) {
+			return nil, insertErr
+		},
+	)
+	require.ErrorIs(t, err, insertErr)
+	require.NoError(t, tree.auditValueStore())
+	assert.Equal(t, before, writeTreeBytes(t, tree),
+		"the failed insert changed the database")
+}
+
+func TestFailedRangeInsertKeepsEarlierSubnets(t *testing.T) {
+	tree := newMetadataTree(t, Options{IPVersion: 4})
+	require.NoError(t, tree.Insert(
+		netip.MustParsePrefix("1.2.3.0/24"),
+		mmdbtype.String("base"),
+	))
+
+	// The range decomposes into four subnets, so failing on the third leaves
+	// two installed and requires splitDepth to be reset for the failing one.
+	insertErr := errors.New("insert failed mid-range")
+	var networks []netip.Prefix
+	var depths []int
+	err := tree.InsertRangeFunc(
+		netip.MustParseAddr("1.2.3.1"),
+		netip.MustParseAddr("1.2.3.6"),
+		mmdbtype.String("overlay"),
+		func(_, newValue mmdbtype.DataType, metadata inserter.Metadata) (
+			mmdbtype.DataType,
+			error,
+		) {
+			networks = append(networks, metadata.InsertedNetwork)
+			depths = append(depths, metadata.ExistingDepth)
+			if len(networks) == 3 {
+				return nil, insertErr
+			}
+			return newValue, nil
+		},
+	)
+	require.ErrorIs(t, err, insertErr)
+	assert.Equal(t, []netip.Prefix{
+		netip.MustParsePrefix("1.2.3.1/32"),
+		netip.MustParsePrefix("1.2.3.2/31"),
+		netip.MustParsePrefix("1.2.3.4/31"),
+	}, networks)
+	// The depths track the fragmentation each subnet leaves behind: the first
+	// splits the /24, the second lands on a /31 the split produced, and the
+	// third resolves through a split chain from a /30, one level shallower
+	// than the subnet being inserted.
+	assert.Equal(t, []int{24, 31, 30}, depths)
+
+	for address, expected := range map[string]mmdbtype.DataType{
+		"1.2.3.0": mmdbtype.String("base"),
+		"1.2.3.1": mmdbtype.String("overlay"),
+		"1.2.3.2": mmdbtype.String("overlay"),
+		"1.2.3.3": mmdbtype.String("overlay"),
+		"1.2.3.4": mmdbtype.String("base"),
+		"1.2.3.6": mmdbtype.String("base"),
+	} {
+		_, value := tree.Get(netip.MustParseAddr(address))
+		assert.Equal(t, expected, value, "wrong value for %s", address)
+	}
+	require.NoError(t, tree.auditValueStore())
+}
+
 func TestFailedInserterRetryMetadata(t *testing.T) {
 	insertMethods := []struct {
 		name   string

--- a/metadata_test.go
+++ b/metadata_test.go
@@ -61,22 +61,13 @@ func TestInserterMetadataRecordShapes(t *testing.T) {
 		))
 
 		require.Len(t, calls, 3)
-		for index, expected := range []struct {
-			network string
-			depth   int
-		}{
-			{network: "1.2.3.0/26", depth: 26},
-			{network: "1.2.3.64/26", depth: 26},
-			{network: "1.2.3.128/25", depth: 25},
-		} {
-			assertMetadata(
-				t,
-				calls[index].metadata,
-				"1.2.3.0/24",
-				expected.network,
-				expected.depth,
-				32,
-			)
+		for index, expectedDepth := range []int{26, 26, 25} {
+			metadata := calls[index].metadata
+			assert.Equal(t, netip.MustParsePrefix("1.2.3.0/24"), metadata.InsertedNetwork)
+			assert.Equal(t, expectedDepth, metadata.ExistingDepth)
+			assert.Equal(t, 32, metadata.TreeDepth)
+			assert.Equal(t, netip.Prefix{}, metadata.ExistingNetwork())
+			assert.Equal(t, [16]byte{}, metadata.ExistingAddr)
 		}
 	})
 
@@ -240,9 +231,14 @@ func TestInserterMetadataRangeSubnets(t *testing.T) {
 		metadata := calls[index].metadata
 		assert.Equal(t, prefix, metadata.InsertedNetwork)
 		assert.Equal(t, prefix.Bits(), metadata.InsertedDepth())
-		assert.Equal(t, expectedExisting[index], metadata.ExistingNetwork())
 		assert.Equal(t, expectedExisting[index].Bits(), metadata.ExistingDepth)
-		assert.Equal(t, treeAddr(expectedExisting[index], 32), metadata.ExistingAddr)
+		if expectedExisting[index].Bits() > prefix.Bits() {
+			assert.Equal(t, netip.Prefix{}, metadata.ExistingNetwork())
+			assert.Equal(t, [16]byte{}, metadata.ExistingAddr)
+		} else {
+			assert.Equal(t, expectedExisting[index], metadata.ExistingNetwork())
+			assert.Equal(t, treeAddr(expectedExisting[index], 32), metadata.ExistingAddr)
+		}
 		assert.Equal(t, 32, metadata.TreeDepth)
 	}
 }
@@ -291,7 +287,7 @@ func TestInserterMetadataUnaliasedIPv6ShallowRecord(t *testing.T) {
 	assert.Equal(t, 120, calls[0].metadata.InsertedDepth())
 }
 
-func TestInserterMetadataAddressCopyAndSiblingTracking(t *testing.T) {
+func TestInserterMetadataNarrowerRecordNetworkFallback(t *testing.T) {
 	tree := newMetadataTree(t, Options{IPVersion: 4})
 	expectedNetworks := []netip.Prefix{
 		netip.MustParsePrefix("1.2.3.0/26"),
@@ -314,9 +310,10 @@ func TestInserterMetadataAddressCopyAndSiblingTracking(t *testing.T) {
 	))
 
 	require.Len(t, calls, len(expectedNetworks))
-	for index, expected := range expectedNetworks {
-		assert.Equal(t, expected, calls[index].metadata.ExistingNetwork())
-		assert.Equal(t, expected.Addr().As4(), [4]byte(calls[index].metadata.ExistingAddr[:4]))
+	for index := range expectedNetworks {
+		assert.Equal(t, 26, calls[index].metadata.ExistingDepth)
+		assert.Equal(t, netip.Prefix{}, calls[index].metadata.ExistingNetwork())
+		assert.Equal(t, [16]byte{}, calls[index].metadata.ExistingAddr)
 	}
 }
 
@@ -365,7 +362,8 @@ func TestInserterMetadataFamilyFollowsInsert(t *testing.T) {
 	})
 	require.NotEqual(t, -1, index)
 	assert.Equal(t, 100, allCalls[index].metadata.ExistingDepth)
-	assert.Equal(t, netip.MustParsePrefix("::/100"), allCalls[index].metadata.ExistingNetwork())
+	assert.Equal(t, netip.Prefix{}, allCalls[index].metadata.ExistingNetwork())
+	assert.Equal(t, [16]byte{}, allCalls[index].metadata.ExistingAddr)
 }
 
 func TestInserterMetadataRootInsert(t *testing.T) {
@@ -380,8 +378,11 @@ func TestInserterMetadataRootInsert(t *testing.T) {
 		captureMetadata(&calls),
 	))
 	require.Len(t, calls, 2)
-	assert.Equal(t, netip.MustParsePrefix("::/1"), calls[0].metadata.ExistingNetwork())
-	assert.Equal(t, netip.MustParsePrefix("8000::/1"), calls[1].metadata.ExistingNetwork())
+	for _, call := range calls {
+		assert.Equal(t, 1, call.metadata.ExistingDepth)
+		assert.Equal(t, netip.Prefix{}, call.metadata.ExistingNetwork())
+		assert.Equal(t, [16]byte{}, call.metadata.ExistingAddr)
+	}
 }
 
 func TestInserterMetadataNormalizesInsertedNetwork(t *testing.T) {
@@ -923,10 +924,12 @@ func metadataOracleRecords(
 			metadata: inserter.Metadata{
 				InsertedNetwork: insertedNetwork,
 				ExistingDepth:   existingNetwork.Bits(),
-				ExistingAddr:    treeAddr(existingNetwork, 32),
 				TreeDepth:       32,
 			},
 		})
+		if existingNetwork.Bits() <= insertedNetwork.Bits() {
+			records[len(records)-1].metadata.ExistingAddr = treeAddr(existingNetwork, 32)
+		}
 	}
 	return records
 }

--- a/node.go
+++ b/node.go
@@ -1,6 +1,7 @@
 package mmdbwriter
 
 import (
+	"errors"
 	"fmt"
 	"net/netip"
 
@@ -345,10 +346,7 @@ func (iRec *insertRecord) insertRecord(
 	switch r.recordType {
 	case recordTypeNode:
 		err := iRec.insertNode(r.nodeIndex, newDepth, splitDepth)
-		if err != nil {
-			return err
-		}
-		return iRec.maybeMergeChildren(r)
+		return iRec.mergeChildrenAfterInsert(r, err)
 	case recordTypeFixedNode:
 		return iRec.insertNode(r.nodeIndex, newDepth, splitDepth)
 	case recordTypePath:
@@ -416,10 +414,7 @@ func (iRec *insertRecord) insertRecord(
 		r.value = nilValueRef
 		r.recordType = recordTypeNode
 		err := iRec.insertNode(r.nodeIndex, newDepth, splitDepth)
-		if err != nil {
-			return err
-		}
-		return iRec.maybeMergeChildren(r)
+		return iRec.mergeChildrenAfterInsert(r, err)
 	case recordTypeReserved:
 		if iRec.prefixLen >= newDepth {
 			return newReservedNetworkError(iRec.ip, newDepth, iRec.prefixLen, iRec.tree.treeDepth)
@@ -438,6 +433,17 @@ func (iRec *insertRecord) insertRecord(
 	default:
 		return fmt.Errorf("inserting into record type %d is not implemented", r.recordType)
 	}
+}
+
+func (iRec *insertRecord) mergeChildrenAfterInsert(r *record, insertErr error) error {
+	mergeErr := iRec.maybeMergeChildren(r)
+	if insertErr == nil {
+		return mergeErr
+	}
+	if mergeErr == nil {
+		return insertErr
+	}
+	return errors.Join(insertErr, mergeErr)
 }
 
 func (iRec *insertRecord) maybeMergeChildren(r *record) error {

--- a/node.go
+++ b/node.go
@@ -477,8 +477,8 @@ func (iRec *insertRecord) insertRecord(
 		if iRec.prefixLen >= newDepth {
 			return newReservedNetworkError(iRec.ip, newDepth, iRec.prefixLen, iRec.tree.treeDepth)
 		}
-		// If we are inserting a network that contains a reserved network,
-		// we silently remove the reserved network.
+		// We are inserting a network that contains a reserved network. Leave
+		// the reserved record as it is, and do not report it to an inserter.
 		return nil
 	case recordTypeAlias:
 		if iRec.prefixLen < newDepth {

--- a/node.go
+++ b/node.go
@@ -166,11 +166,14 @@ func (iRec *insertRecord) resolve(
 			ExistingDepth:   existingDepth,
 			TreeDepth:       iRec.tree.treeDepth,
 		}
-		switch {
-		case existingDepth == iRec.prefixLen:
-			// ip is already masked at prefixLen, so no masking is needed.
+		if existingDepth == iRec.prefixLen {
+			// ip is masked at prefixLen and the walk has not descended past
+			// it, so no masking is needed.
 			metadata.ExistingAddr = iRec.ip
-		case existingDepth < iRec.prefixLen:
+		} else {
+			// Shallower records sit in a split chain, which leaves ip's deeper
+			// bits zero. Deeper records carry the descent path insertNode
+			// wrote, and masking drops the bits past this record.
 			metadata.ExistingAddr = maskedTreeAddr(iRec.ip, existingDepth)
 		}
 		result, err = iRec.resolver.withMetadata(
@@ -365,10 +368,21 @@ func (iRec *insertRecord) insertNode(
 	if newDepth > iRec.prefixLen {
 		// Data already exists for the network so insert into all the children.
 		// Identical child records are merged as recursion unwinds.
+		//
+		// Record which child we take in iRec.ip. Navigation no longer reads
+		// these bits once the walk is deeper than prefixLen, so they can carry
+		// the descent path that metadata needs to report a record more
+		// specific than the insert. Both branches write the bit, because a
+		// sibling subtree may have left it set. Nothing restores it:
+		// maskedTreeAddr drops every bit past the record's own depth,
+		// PrefixFromInsertIP masks at prefixLen, and insertPrepared overwrites
+		// ip for the next subnet of a range.
+		setBitAt(&iRec.ip, currentDepth, 0)
 		err := iRec.insertRecord(&node.children[0], newDepth)
 		if err != nil {
 			return err
 		}
+		setBitAt(&iRec.ip, currentDepth, 1)
 		return iRec.insertRecord(&node.children[1], newDepth)
 	}
 
@@ -603,6 +617,13 @@ func (t *Tree) finalizeNode(index nodeIndex, currentNum int) int {
 
 func bitAt(ip [16]byte, depth int) byte {
 	return (ip[depth/8] >> (7 - (depth % 8))) & 1
+}
+
+// setBitAt sets the bit at depth in ip to bit, which must be 0 or 1.
+func setBitAt(ip *[16]byte, depth int, bit byte) {
+	shift := 7 - (depth % 8)
+	mask := byte(1) << shift
+	ip[depth/8] = ip[depth/8]&^mask | bit<<shift
 }
 
 func maskedTreeAddr(ip [16]byte, depth int) [16]byte {

--- a/node.go
+++ b/node.go
@@ -59,7 +59,7 @@ const (
 //   - the memo fields, which resolve updates as it goes.
 //
 // The memo is only used for pure inserters. It is keyed on the existing value
-// alone, which is sound only because inserter and value are fixed: reusing an
+// alone, which is sound only because the resolver and value are fixed: reusing an
 // insertRecord across inserts with a different value would return results
 // computed from the previous one.
 //
@@ -68,18 +68,15 @@ const (
 // memo references and the reference interned for the inserted value itself.
 // memoFirst and memoResult hold the single entry until a second distinct key
 // promotes both into memo, which clears them.
+//
+// Fields are ordered widest first. The struct is one allocation per insert
+// call, and this layout keeps it inside the 128-byte size class.
 type insertRecord struct {
-	inserter inserter.Func
+	resolver insertResolver
 
-	store        *valueStore
-	tree         *Tree
-	insertedNode nodeIndex
+	store *valueStore
+	tree  *Tree
 
-	ip        [16]byte
-	prefixLen int
-
-	recordType recordType
-	value      valueRef
 	// valueView is the value handed to the inserter as its new-value argument:
 	// the caller's value as passed for the insert entry points, or a
 	// store-materialized view when the insert began from an interned
@@ -89,29 +86,53 @@ type insertRecord struct {
 	// registered only after the insert succeeds, so a failed insert cannot
 	// serve stale data if the caller mutates and retries the object.
 	callerValue mmdbtype.DataType
+	memo        map[valueRef]valueRef
+
+	prefixLen int
+	ip        [16]byte
+
+	insertedNode nodeIndex
+	value        valueRef
+	memoFirst    valueRef
+	memoResult   valueRef
+
+	recordType recordType
 	// insertedAs4 records the address family that the tree-space ip cannot
-	// encode. It fits in existing struct padding, unlike retaining a
-	// netip.Prefix on every insertRecord.
-	insertedAs4  bool
-	inserterPure bool
+	// encode. A netip.Prefix field would carry it directly, but at 32 bytes
+	// it pushes the struct into the next size class, while a pointer to a
+	// prepared Metadata escapes to the heap once per insertRange call. The
+	// flag fits in padding, and rebuilding the prefix per record measures at
+	// about 4ns.
+	insertedAs4 bool
 	// splitDepth is the first pre-insert record depth in a split chain. Tree
 	// depths are at most 128, and zero is the sentinel for no active split.
 	splitDepth uint8
-	memo       map[valueRef]valueRef
-	memoFirst  valueRef
-	memoResult valueRef
 	memoSet    bool
+}
+
+// resolveValue returns the reference for a record and whether the caller owns
+// it. With no inserter the reference interned when the insert began is reused
+// directly: the store canonicalizes by content, so an equal existing value is
+// the same reference and replaceDataRecord makes the assignment a no-op.
+func (iRec *insertRecord) resolveValue(
+	existing valueRef,
+	existingDepth int,
+) (valueRef, bool, error) {
+	if !iRec.resolver.hasFunc() {
+		return iRec.value, false, nil
+	}
+	return iRec.resolve(existing, existingDepth)
 }
 
 // resolve returns a reference and whether the caller owns it. A pure
 // inserter's memo owns one reference to each non-nil result until insertion
-// finishes. An ordinary Func is not memoized, so a newly interned reference is
-// transferred directly to the target record.
+// finishes. A metadata-aware Func is not memoized, so a newly interned
+// reference is transferred directly to the target record.
 func (iRec *insertRecord) resolve(
 	existing valueRef,
 	existingDepth int,
 ) (valueRef, bool, error) {
-	if iRec.inserterPure {
+	if iRec.resolver.pure != nil {
 		if iRec.memo != nil {
 			if value, ok := iRec.memo[existing]; ok {
 				return value, false, nil
@@ -120,38 +141,49 @@ func (iRec *insertRecord) resolve(
 			return iRec.memoResult, false, nil
 		}
 	}
-	metadata := inserter.Metadata{}
-	if !iRec.inserterPure {
-		insertedNetwork, err := treeaddr.PrefixFromInsertIP(
+	var result mmdbtype.DataType
+	var err error
+	if iRec.resolver.pure != nil {
+		result, err = iRec.resolver.pure(
+			iRec.store.materialize(existing),
+			iRec.valueView,
+		)
+	} else {
+		insertedNetwork, metadataErr := treeaddr.PrefixFromInsertIP(
 			iRec.ip,
 			iRec.prefixLen,
 			iRec.tree.treeDepth,
 			iRec.insertedAs4,
 		)
-		if err != nil {
-			return nilValueRef, false, fmt.Errorf("creating inserted network metadata: %w", err)
+		if metadataErr != nil {
+			return nilValueRef, false, fmt.Errorf(
+				"creating inserted network metadata: %w",
+				metadataErr,
+			)
 		}
-		var existingAddr [16]byte
-		if existingDepth <= iRec.prefixLen {
-			existingAddr = maskedTreeAddr(iRec.ip, existingDepth)
-		}
-		metadata = inserter.Metadata{
+		metadata := inserter.Metadata{
 			InsertedNetwork: insertedNetwork,
 			ExistingDepth:   existingDepth,
-			ExistingAddr:    existingAddr,
 			TreeDepth:       iRec.tree.treeDepth,
 		}
+		switch {
+		case existingDepth == iRec.prefixLen:
+			// ip is already masked at prefixLen, so no masking is needed.
+			metadata.ExistingAddr = iRec.ip
+		case existingDepth < iRec.prefixLen:
+			metadata.ExistingAddr = maskedTreeAddr(iRec.ip, existingDepth)
+		}
+		result, err = iRec.resolver.withMetadata(
+			iRec.store.materialize(existing),
+			iRec.valueView,
+			metadata,
+		)
 	}
-	result, err := iRec.inserter(
-		iRec.store.materialize(existing),
-		iRec.valueView,
-		metadata,
-	)
 	if err != nil {
 		return nilValueRef, false, err
 	}
 	if result == nil {
-		if iRec.inserterPure {
+		if iRec.resolver.pure != nil {
 			iRec.rememberResolved(existing, nilValueRef)
 		}
 		return nilValueRef, false, nil
@@ -166,7 +198,7 @@ func (iRec *insertRecord) resolve(
 	if err != nil {
 		return nilValueRef, false, err
 	}
-	if iRec.inserterPure {
+	if iRec.resolver.pure != nil {
 		iRec.rememberResolved(existing, value)
 		return value, false, nil
 	}
@@ -373,12 +405,7 @@ func (iRec *insertRecord) insertRecord(
 				if iRec.splitDepth != 0 {
 					existingDepth = int(iRec.splitDepth)
 				}
-				value := iRec.value
-				owned := false
-				var err error
-				if iRec.inserter != nil {
-					value, owned, err = iRec.resolve(r.value, existingDepth)
-				}
+				value, owned, err := iRec.resolveValue(r.value, existingDepth)
 				if err != nil {
 					return err
 				}
@@ -398,12 +425,7 @@ func (iRec *insertRecord) insertRecord(
 		}
 
 		if r.recordType == recordTypeEmpty && iRec.recordType == recordTypeData {
-			value := iRec.value
-			owned := false
-			var err error
-			if iRec.inserter != nil {
-				value, owned, err = iRec.resolve(nilValueRef, newDepth)
-			}
+			value, owned, err := iRec.resolveValue(nilValueRef, newDepth)
 			if err != nil {
 				return err
 			}

--- a/node.go
+++ b/node.go
@@ -498,7 +498,12 @@ func (iRec *insertRecord) mergeChildrenAfterError(r *record, insertErr error) er
 	if mergeErr == nil {
 		return insertErr
 	}
-	return errors.Join(insertErr, mergeErr)
+	// Name the source, so a log reader can tell a failure to restore the record
+	// boundaries from the insert failure that triggered the restore.
+	return errors.Join(insertErr, fmt.Errorf(
+		"restoring record boundaries after insert failure: %w",
+		mergeErr,
+	))
 }
 
 func (iRec *insertRecord) maybeMergeChildren(r *record) error {

--- a/node.go
+++ b/node.go
@@ -2,7 +2,9 @@ package mmdbwriter
 
 import (
 	"fmt"
+	"net/netip"
 
+	"github.com/maxmind/mmdbwriter/v2/inserter"
 	"github.com/maxmind/mmdbwriter/v2/mmdbtype"
 )
 
@@ -47,9 +49,9 @@ const (
 )
 
 // insertRecord carries the state for one insert call. Every field except ip,
-// prefixLen, and the memo fields is fixed for the life of the value;
-// insertPrepared re-targets ip and prefixLen for each subnet of a range, and
-// resolve updates the memo as it goes.
+// prefixLen, network, and the memo fields is fixed for the life of the value;
+// insertPrepared re-targets ip, prefixLen, and network for each subnet of a
+// range, and resolve updates the memo as it goes.
 //
 // The memo is only used for pure inserters. It is keyed on the existing value
 // alone, which is sound only because inserter and value are fixed: reusing an
@@ -62,7 +64,7 @@ const (
 // memoFirst and memoResult hold the single entry until a second distinct key
 // promotes both into memo, which clears them.
 type insertRecord struct {
-	inserter func(existingValue, newValue mmdbtype.DataType) (mmdbtype.DataType, error)
+	inserter inserter.Func
 
 	store        *valueStore
 	tree         *Tree
@@ -70,6 +72,7 @@ type insertRecord struct {
 
 	ip        [16]byte
 	prefixLen int
+	network   netip.Prefix
 
 	recordType recordType
 	value      valueRef
@@ -93,9 +96,12 @@ type insertRecord struct {
 // it. With no inserter the reference interned when the insert began is reused
 // directly; the store canonicalizes by content, so an equal existing value is
 // the same reference and replaceDataRecord makes the assignment a no-op.
-func (iRec *insertRecord) resolveValue(existing valueRef) (valueRef, bool, error) {
+func (iRec *insertRecord) resolveValue(
+	existing valueRef,
+	existingDepth int,
+) (valueRef, bool, error) {
 	if iRec.inserter != nil {
-		return iRec.resolve(existing)
+		return iRec.resolve(existing, existingDepth)
 	}
 	return iRec.value, false, nil
 }
@@ -104,7 +110,10 @@ func (iRec *insertRecord) resolveValue(existing valueRef) (valueRef, bool, error
 // inserter's memo owns one reference to each non-nil result until insertion
 // finishes. An ordinary Func is not memoized, so a newly interned reference is
 // transferred directly to the target record.
-func (iRec *insertRecord) resolve(existing valueRef) (valueRef, bool, error) {
+func (iRec *insertRecord) resolve(
+	existing valueRef,
+	existingDepth int,
+) (valueRef, bool, error) {
 	if iRec.inserterPure {
 		if iRec.memo != nil {
 			if value, ok := iRec.memo[existing]; ok {
@@ -114,7 +123,20 @@ func (iRec *insertRecord) resolve(existing valueRef) (valueRef, bool, error) {
 			return iRec.memoResult, false, nil
 		}
 	}
-	result, err := iRec.inserter(iRec.store.materialize(existing), iRec.valueView)
+	metadata := inserter.Metadata{}
+	if !iRec.inserterPure {
+		metadata = inserter.Metadata{
+			InsertedNetwork: iRec.network,
+			ExistingDepth:   existingDepth,
+			ExistingAddr:    maskedTreeAddr(iRec.ip, existingDepth),
+			TreeDepth:       iRec.tree.treeDepth,
+		}
+	}
+	result, err := iRec.inserter(
+		iRec.store.materialize(existing),
+		iRec.valueView,
+		metadata,
+	)
 	if err != nil {
 		return nilValueRef, false, err
 	}
@@ -285,38 +307,50 @@ func (t *Tree) materializePath(startDepth int, path compressedPath) record {
 	return child
 }
 
-func (iRec *insertRecord) insertNode(index nodeIndex, currentDepth int) error {
+func (iRec *insertRecord) insertNode(
+	index nodeIndex,
+	currentDepth,
+	splitDepth int,
+) error {
+	// A split chain descends through one child from splitDepth to prefixLen:
+	// splitting only happens above prefixLen, so the next insertNode takes the
+	// single-child path. Below prefixLen, records resolve at their own depths
+	// and are never split. The two depths are therefore never both live, and
+	// splitDepth alone preserves the pre-insert record extent.
 	newDepth := currentDepth + 1
 	node := iRec.tree.nodeAt(index)
 	// Check if we are inside the network already
 	if newDepth > iRec.prefixLen {
 		// Data already exists for the network so insert into all the children.
 		// Identical child records are merged as recursion unwinds.
-		err := iRec.insertRecord(&node.children[0], newDepth)
+		clearBit(&iRec.ip, currentDepth)
+		err := iRec.insertRecord(&node.children[0], newDepth, splitDepth)
 		if err != nil {
 			return err
 		}
-		return iRec.insertRecord(&node.children[1], newDepth)
+		setBit(&iRec.ip, currentDepth)
+		return iRec.insertRecord(&node.children[1], newDepth, splitDepth)
 	}
 
 	// We haven't reached the network yet.
 	pos := bitAt(iRec.ip, currentDepth)
-	return iRec.insertRecord(&node.children[pos], newDepth)
+	return iRec.insertRecord(&node.children[pos], newDepth, splitDepth)
 }
 
 func (iRec *insertRecord) insertRecord(
 	r *record,
-	newDepth int,
+	newDepth,
+	splitDepth int,
 ) error {
 	switch r.recordType {
 	case recordTypeNode:
-		err := iRec.insertNode(r.nodeIndex, newDepth)
+		err := iRec.insertNode(r.nodeIndex, newDepth, splitDepth)
 		if err != nil {
 			return err
 		}
 		return iRec.maybeMergeChildren(r)
 	case recordTypeFixedNode:
-		return iRec.insertNode(r.nodeIndex, newDepth)
+		return iRec.insertNode(r.nodeIndex, newDepth, splitDepth)
 	case recordTypePath:
 		path := iRec.tree.paths[r.nodeIndex]
 		// materializePath moves the path record's value ownership into the
@@ -324,11 +358,15 @@ func (iRec *insertRecord) insertRecord(
 		// fails loudly instead of double-counting the moved reference.
 		iRec.tree.paths[r.nodeIndex].record = record{}
 		*r = iRec.tree.materializePath(newDepth, path)
-		return iRec.insertRecord(r, newDepth)
+		return iRec.insertRecord(r, newDepth, splitDepth)
 	case recordTypeEmpty, recordTypeData:
 		if newDepth >= iRec.prefixLen {
 			if iRec.recordType == recordTypeData {
-				value, owned, err := iRec.resolveValue(r.value)
+				existingDepth := newDepth
+				if splitDepth != 0 {
+					existingDepth = splitDepth
+				}
+				value, owned, err := iRec.resolveValue(r.value, existingDepth)
 				if err != nil {
 					return err
 				}
@@ -348,7 +386,7 @@ func (iRec *insertRecord) insertRecord(
 		}
 
 		if r.recordType == recordTypeEmpty && iRec.recordType == recordTypeData {
-			value, owned, err := iRec.resolveValue(nilValueRef)
+			value, owned, err := iRec.resolveValue(nilValueRef, newDepth)
 			if err != nil {
 				return err
 			}
@@ -368,13 +406,16 @@ func (iRec *insertRecord) insertRecord(
 
 		// We are splitting this record so we create two duplicate child
 		// records.
+		if splitDepth == 0 {
+			splitDepth = newDepth
+		}
 		if r.recordType == recordTypeData {
 			iRec.store.retain(r.value)
 		}
 		r.nodeIndex = iRec.tree.newNode([2]record{*r, *r})
 		r.value = nilValueRef
 		r.recordType = recordTypeNode
-		err := iRec.insertNode(r.nodeIndex, newDepth)
+		err := iRec.insertNode(r.nodeIndex, newDepth, splitDepth)
 		if err != nil {
 			return err
 		}
@@ -515,4 +556,22 @@ func (t *Tree) finalizeNode(index nodeIndex, currentNum int) int {
 
 func bitAt(ip [16]byte, depth int) byte {
 	return (ip[depth/8] >> (7 - (depth % 8))) & 1
+}
+
+func clearBit(ip *[16]byte, depth int) {
+	ip[depth/8] &^= 1 << (7 - (depth % 8))
+}
+
+func setBit(ip *[16]byte, depth int) {
+	ip[depth/8] |= 1 << (7 - (depth % 8))
+}
+
+func maskedTreeAddr(ip [16]byte, depth int) [16]byte {
+	byteIndex := depth / 8
+	if remainingBits := depth % 8; remainingBits != 0 {
+		ip[byteIndex] &= byte(0xff << (8 - remainingBits))
+		byteIndex++
+	}
+	clear(ip[byteIndex:])
+	return ip
 }

--- a/node.go
+++ b/node.go
@@ -3,9 +3,9 @@ package mmdbwriter
 import (
 	"errors"
 	"fmt"
-	"net/netip"
 
 	"github.com/maxmind/mmdbwriter/v2/inserter"
+	"github.com/maxmind/mmdbwriter/v2/internal/treeaddr"
 	"github.com/maxmind/mmdbwriter/v2/mmdbtype"
 )
 
@@ -49,10 +49,14 @@ const (
 	nodeBlockSize           = 1024
 )
 
-// insertRecord carries the state for one insert call. Every field except ip,
-// prefixLen, network, and the memo fields is fixed for the life of the value;
-// insertPrepared re-targets ip, prefixLen, and network for each subnet of a
-// range, and resolve updates the memo as it goes.
+// insertRecord carries the state for one insert call. Most fields are fixed for
+// the life of the value. These are not:
+//
+//   - ip, prefixLen, and insertedAs4, which insertPrepared re-targets for each
+//     subnet of a range.
+//   - splitDepth, which insertPrepared resets for each subnet and traversal
+//     sets when it splits a record.
+//   - the memo fields, which resolve updates as it goes.
 //
 // The memo is only used for pure inserters. It is keyed on the existing value
 // alone, which is sound only because inserter and value are fixed: reusing an
@@ -73,7 +77,6 @@ type insertRecord struct {
 
 	ip        [16]byte
 	prefixLen int
-	network   netip.Prefix
 
 	recordType recordType
 	value      valueRef
@@ -85,26 +88,19 @@ type insertRecord struct {
 	// callerValue is the caller's object for a direct insert. Its identity is
 	// registered only after the insert succeeds, so a failed insert cannot
 	// serve stale data if the caller mutates and retries the object.
-	callerValue  mmdbtype.DataType
+	callerValue mmdbtype.DataType
+	// insertedAs4 records the address family that the tree-space ip cannot
+	// encode. It fits in existing struct padding, unlike retaining a
+	// netip.Prefix on every insertRecord.
+	insertedAs4  bool
 	inserterPure bool
-	memo         map[valueRef]valueRef
-	memoFirst    valueRef
-	memoResult   valueRef
-	memoSet      bool
-}
-
-// resolveValue returns the reference for a record and whether the caller owns
-// it. With no inserter the reference interned when the insert began is reused
-// directly; the store canonicalizes by content, so an equal existing value is
-// the same reference and replaceDataRecord makes the assignment a no-op.
-func (iRec *insertRecord) resolveValue(
-	existing valueRef,
-	existingDepth int,
-) (valueRef, bool, error) {
-	if iRec.inserter != nil {
-		return iRec.resolve(existing, existingDepth)
-	}
-	return iRec.value, false, nil
+	// splitDepth is the first pre-insert record depth in a split chain. Tree
+	// depths are at most 128, and zero is the sentinel for no active split.
+	splitDepth uint8
+	memo       map[valueRef]valueRef
+	memoFirst  valueRef
+	memoResult valueRef
+	memoSet    bool
 }
 
 // resolve returns a reference and whether the caller owns it. A pure
@@ -126,10 +122,23 @@ func (iRec *insertRecord) resolve(
 	}
 	metadata := inserter.Metadata{}
 	if !iRec.inserterPure {
+		insertedNetwork, err := treeaddr.PrefixFromInsertIP(
+			iRec.ip,
+			iRec.prefixLen,
+			iRec.tree.treeDepth,
+			iRec.insertedAs4,
+		)
+		if err != nil {
+			return nilValueRef, false, fmt.Errorf("creating inserted network metadata: %w", err)
+		}
+		var existingAddr [16]byte
+		if existingDepth <= iRec.prefixLen {
+			existingAddr = maskedTreeAddr(iRec.ip, existingDepth)
+		}
 		metadata = inserter.Metadata{
-			InsertedNetwork: iRec.network,
+			InsertedNetwork: insertedNetwork,
 			ExistingDepth:   existingDepth,
-			ExistingAddr:    maskedTreeAddr(iRec.ip, existingDepth),
+			ExistingAddr:    existingAddr,
 			TreeDepth:       iRec.tree.treeDepth,
 		}
 	}
@@ -310,45 +319,45 @@ func (t *Tree) materializePath(startDepth int, path compressedPath) record {
 
 func (iRec *insertRecord) insertNode(
 	index nodeIndex,
-	currentDepth,
-	splitDepth int,
+	currentDepth int,
 ) error {
 	// A split chain descends through one child from splitDepth to prefixLen:
 	// splitting only happens above prefixLen, so the next insertNode takes the
 	// single-child path. Below prefixLen, records resolve at their own depths
 	// and are never split. The two depths are therefore never both live, and
-	// splitDepth alone preserves the pre-insert record extent.
+	// iRec.splitDepth alone preserves the pre-insert record boundary without
+	// adding a parameter to every recursive call.
 	newDepth := currentDepth + 1
 	node := iRec.tree.nodeAt(index)
 	// Check if we are inside the network already
 	if newDepth > iRec.prefixLen {
 		// Data already exists for the network so insert into all the children.
 		// Identical child records are merged as recursion unwinds.
-		clearBit(&iRec.ip, currentDepth)
-		err := iRec.insertRecord(&node.children[0], newDepth, splitDepth)
+		err := iRec.insertRecord(&node.children[0], newDepth)
 		if err != nil {
 			return err
 		}
-		setBit(&iRec.ip, currentDepth)
-		return iRec.insertRecord(&node.children[1], newDepth, splitDepth)
+		return iRec.insertRecord(&node.children[1], newDepth)
 	}
 
 	// We haven't reached the network yet.
 	pos := bitAt(iRec.ip, currentDepth)
-	return iRec.insertRecord(&node.children[pos], newDepth, splitDepth)
+	return iRec.insertRecord(&node.children[pos], newDepth)
 }
 
 func (iRec *insertRecord) insertRecord(
 	r *record,
-	newDepth,
-	splitDepth int,
+	newDepth int,
 ) error {
 	switch r.recordType {
 	case recordTypeNode:
-		err := iRec.insertNode(r.nodeIndex, newDepth, splitDepth)
-		return iRec.mergeChildrenAfterInsert(r, err)
+		err := iRec.insertNode(r.nodeIndex, newDepth)
+		if err != nil {
+			return iRec.mergeChildrenAfterError(r, err)
+		}
+		return iRec.maybeMergeChildren(r)
 	case recordTypeFixedNode:
-		return iRec.insertNode(r.nodeIndex, newDepth, splitDepth)
+		return iRec.insertNode(r.nodeIndex, newDepth)
 	case recordTypePath:
 		path := iRec.tree.paths[r.nodeIndex]
 		// materializePath moves the path record's value ownership into the
@@ -356,15 +365,20 @@ func (iRec *insertRecord) insertRecord(
 		// fails loudly instead of double-counting the moved reference.
 		iRec.tree.paths[r.nodeIndex].record = record{}
 		*r = iRec.tree.materializePath(newDepth, path)
-		return iRec.insertRecord(r, newDepth, splitDepth)
+		return iRec.insertRecord(r, newDepth)
 	case recordTypeEmpty, recordTypeData:
 		if newDepth >= iRec.prefixLen {
 			if iRec.recordType == recordTypeData {
 				existingDepth := newDepth
-				if splitDepth != 0 {
-					existingDepth = splitDepth
+				if iRec.splitDepth != 0 {
+					existingDepth = int(iRec.splitDepth)
 				}
-				value, owned, err := iRec.resolveValue(r.value, existingDepth)
+				value := iRec.value
+				owned := false
+				var err error
+				if iRec.inserter != nil {
+					value, owned, err = iRec.resolve(r.value, existingDepth)
+				}
 				if err != nil {
 					return err
 				}
@@ -384,7 +398,12 @@ func (iRec *insertRecord) insertRecord(
 		}
 
 		if r.recordType == recordTypeEmpty && iRec.recordType == recordTypeData {
-			value, owned, err := iRec.resolveValue(nilValueRef, newDepth)
+			value := iRec.value
+			owned := false
+			var err error
+			if iRec.inserter != nil {
+				value, owned, err = iRec.resolve(nilValueRef, newDepth)
+			}
 			if err != nil {
 				return err
 			}
@@ -404,8 +423,8 @@ func (iRec *insertRecord) insertRecord(
 
 		// We are splitting this record so we create two duplicate child
 		// records.
-		if splitDepth == 0 {
-			splitDepth = newDepth
+		if iRec.splitDepth == 0 {
+			iRec.splitDepth = uint8(newDepth) //nolint:gosec // Tree depths cannot exceed 128.
 		}
 		if r.recordType == recordTypeData {
 			iRec.store.retain(r.value)
@@ -413,8 +432,11 @@ func (iRec *insertRecord) insertRecord(
 		r.nodeIndex = iRec.tree.newNode([2]record{*r, *r})
 		r.value = nilValueRef
 		r.recordType = recordTypeNode
-		err := iRec.insertNode(r.nodeIndex, newDepth, splitDepth)
-		return iRec.mergeChildrenAfterInsert(r, err)
+		err := iRec.insertNode(r.nodeIndex, newDepth)
+		if err != nil {
+			return iRec.mergeChildrenAfterError(r, err)
+		}
+		return iRec.maybeMergeChildren(r)
 	case recordTypeReserved:
 		if iRec.prefixLen >= newDepth {
 			return newReservedNetworkError(iRec.ip, newDepth, iRec.prefixLen, iRec.tree.treeDepth)
@@ -435,11 +457,8 @@ func (iRec *insertRecord) insertRecord(
 	}
 }
 
-func (iRec *insertRecord) mergeChildrenAfterInsert(r *record, insertErr error) error {
+func (iRec *insertRecord) mergeChildrenAfterError(r *record, insertErr error) error {
 	mergeErr := iRec.maybeMergeChildren(r)
-	if insertErr == nil {
-		return mergeErr
-	}
 	if mergeErr == nil {
 		return insertErr
 	}
@@ -562,14 +581,6 @@ func (t *Tree) finalizeNode(index nodeIndex, currentNum int) int {
 
 func bitAt(ip [16]byte, depth int) byte {
 	return (ip[depth/8] >> (7 - (depth % 8))) & 1
-}
-
-func clearBit(ip *[16]byte, depth int) {
-	ip[depth/8] &^= 1 << (7 - (depth % 8))
-}
-
-func setBit(ip *[16]byte, depth int) {
-	ip[depth/8] |= 1 << (7 - (depth % 8))
 }
 
 func maskedTreeAddr(ip [16]byte, depth int) [16]byte {

--- a/node.go
+++ b/node.go
@@ -52,8 +52,8 @@ const (
 // insertRecord carries the state for one insert call. Most fields are fixed for
 // the life of the value. These are not:
 //
-//   - ip, prefixLen, and insertedAs4, which insertPrepared re-targets for each
-//     subnet of a range.
+//   - ip, prefixLen, and insertedAs4, which insertPrepared re-targets for every
+//     subnet of a range, on every insert path.
 //   - splitDepth, which insertPrepared resets for each subnet and traversal
 //     sets when it splits a record.
 //   - the memo fields, which resolve updates as it goes.
@@ -103,6 +103,9 @@ type insertRecord struct {
 	// prepared Metadata escapes to the heap once per insertRange call. The
 	// flag fits in padding, and rebuilding the prefix per record measures at
 	// about 4ns.
+	//
+	// Only the metadata path reads it, but every path maintains it, so it can
+	// never hold a value from an earlier insert.
 	insertedAs4 bool
 	// splitDepth is the depth of the record a split chain started from, which
 	// is the extent that record had before this insertion. Tree depths are at

--- a/node.go
+++ b/node.go
@@ -104,8 +104,17 @@ type insertRecord struct {
 	// flag fits in padding, and rebuilding the prefix per record measures at
 	// about 4ns.
 	insertedAs4 bool
-	// splitDepth is the first pre-insert record depth in a split chain. Tree
-	// depths are at most 128, and zero is the sentinel for no active split.
+	// splitDepth is the depth of the record a split chain started from, which
+	// is the extent that record had before this insertion. Tree depths are at
+	// most 128, and zero is the sentinel for no active split.
+	//
+	// One field is enough for the whole walk, because a split chain and a
+	// descent deeper than prefixLen are never live at the same time. Splitting
+	// happens only at a record shallower than prefixLen, and the chain then
+	// descends through a single child until it resolves at exactly prefixLen.
+	// Records deeper than prefixLen resolve at their own depth and are never
+	// split. Threading the depth through every recursive call would buy
+	// nothing.
 	splitDepth uint8
 	memoSet    bool
 }
@@ -356,12 +365,6 @@ func (iRec *insertRecord) insertNode(
 	index nodeIndex,
 	currentDepth int,
 ) error {
-	// A split chain descends through one child from splitDepth to prefixLen:
-	// splitting only happens above prefixLen, so the next insertNode takes the
-	// single-child path. Below prefixLen, records resolve at their own depths
-	// and are never split. The two depths are therefore never both live, and
-	// iRec.splitDepth alone preserves the pre-insert record boundary without
-	// adding a parameter to every recursive call.
 	newDepth := currentDepth + 1
 	node := iRec.tree.nodeAt(index)
 	// Check if we are inside the network already
@@ -439,6 +442,9 @@ func (iRec *insertRecord) insertRecord(
 		}
 
 		if r.recordType == recordTypeEmpty && iRec.recordType == recordTypeData {
+			// newDepth is the record's own extent, with no splitDepth check.
+			// Only a data record splits, so a split chain never descends into
+			// an empty record and splitDepth is necessarily zero here.
 			value, owned, err := iRec.resolveValue(nilValueRef, newDepth)
 			if err != nil {
 				return err

--- a/reserved.go
+++ b/reserved.go
@@ -2,7 +2,7 @@ package mmdbwriter
 
 // These were taken from the Perl writer.
 //
-// https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml
+// https://www.iana.org/assignments/iana-ipv4-special-registry
 var reservedNetworksIPv4 = []string{
 	"0.0.0.0/8",
 	"10.0.0.0/8",
@@ -39,7 +39,7 @@ var reservedNetworksIPv4 = []string{
 	// 255.255.255.255/32 gets brought in by 240.0.0.0/4.
 }
 
-// https://www.iana.org/assignments/iana-ipv6-special-registry/iana-ipv6-special-registry.xhtml
+// https://www.iana.org/assignments/iana-ipv6-special-registry
 var reservedNetworksIPv6 = []string{
 	// ::/128 and ::1/128 are reserved under IPv6 but these are already
 	// covered under 0.0.0.0/8.

--- a/tree.go
+++ b/tree.go
@@ -507,9 +507,7 @@ func (t *Tree) insertPrepared(
 	iRec.ip = ip
 	iRec.prefixLen = prefixLen
 	iRec.splitDepth = 0
-	if iRec.resolver.withMetadata != nil {
-		iRec.insertedAs4 = prefix.Addr().Is4()
-	}
+	iRec.insertedAs4 = prefix.Addr().Is4()
 	return iRec.insertNode(t.root, 0)
 }
 

--- a/tree.go
+++ b/tree.go
@@ -87,36 +87,20 @@ type Options struct {
 	// tree in the process.
 	RefcountAudit bool
 
-	// Inserter is the function used when calling `Insert`. Leaving it nil
-	// is equivalent to `inserter.Replace`, which replaces any conflicting old
-	// value entirely with the new, and allows Insert to use the default
-	// direct-value fast path. Passing `inserter.Replace` explicitly has the same
-	// behavior but skips that optimization.
+	// Inserter is the pure function used by Insert, InsertRange, and Load.
+	// Leaving it nil is equivalent to inserter.Replace, which replaces any
+	// conflicting old value entirely with the new, and allows Insert and
+	// InsertRange to use the default direct-value fast path. Passing
+	// inserter.Replace explicitly has the same behavior but skips that
+	// optimization.
 	//
-	// An Inserter must not modify either value argument. The existing value is a
-	// shared, read-only view. It is equal to, but not necessarily the same
-	// object as, the value originally inserted. The new value is the value
-	// passed to the insert call, or a shared view of the decoded record
-	// during Load. Nested containers can be shared across records, so copy a
-	// value before you modify it. The tree calls the function separately for
-	// every covered record. Any non-nil returned value becomes tree-owned and
-	// must not be modified after return.
+	// inserter.PureFunc documents the rules an Inserter must follow: purity,
+	// which values it may modify, and which unvalidated inputs it can receive.
+	// The existing value it sees is equal to, but not necessarily the same
+	// object as, the value originally inserted.
 	//
-	// The function also receives metadata for the insertion and for the record
-	// containing the existing value as it stood before the current insertion
-	// began mutating it. During Load, InsertedNetwork is the normalized network
-	// of the source record. During a range insert, it is each individual prefix
-	// into which the range decomposes.
-	//
-	// Only direct inserts and inserter results are validated, so the function
-	// can receive an unsupported input value, such as a raw mmdbtype.Pointer,
-	// and must replace or discard it. If the function returns an error partway
-	// through the covered records, the records already visited keep their new
-	// values. A failure before any result is installed leaves values, record
-	// extents, and lookups logically unchanged, although internal representation
-	// and arena allocation are not restored. After a partial success, installed
-	// equal values may coalesce, so a retry can observe merged extents.
-	Inserter inserter.Func
+	// The partial-failure behavior is the same as InsertFunc's.
+	Inserter inserter.PureFunc
 }
 
 // Tree represents a MaxMind DB search tree. A Tree is not safe for
@@ -146,7 +130,7 @@ type Tree struct {
 	treeDepth int
 
 	nodeCount int
-	inserter  inserter.Func
+	inserter  inserter.PureFunc
 	// refcountAudit runs the full ownership audit after every insert that
 	// reaches the value store and after every successful load. New sets it from
 	// Options.RefcountAudit or the MMDBWRITER_REFCOUNT_AUDIT environment variable.
@@ -248,11 +232,10 @@ func metadataDimension(name string, value uint) (int, error) {
 // map and slice graphs. Source networks that share a data offset share one
 // stored value.
 // During the load, a cache holds one reference per distinct offset in the
-// source data section. Load releases the cache before it returns. A
-// non-nil Options.Inserter also receives a materialized view of each decoded
-// record and metadata whose InsertedNetwork is the normalized source-record
-// network. The inserter must treat its value arguments as immutable and must
-// copy a value before modifying it.
+// source data section. Load releases the cache before it returns. A non-nil
+// Options.Inserter also receives a materialized view of each decoded
+// record. The inserter must treat its value arguments as immutable and must copy
+// a value before modifying it.
 func Load(path string, opts Options) (*Tree, error) {
 	db, err := maxminddb.Open(path)
 	if err != nil {
@@ -369,7 +352,13 @@ func (t *Tree) normalizeLoadPrefix(prefix netip.Prefix) (netip.Prefix, error) {
 //
 // This is not safe to call from multiple threads.
 func (t *Tree) Insert(prefix netip.Prefix, value mmdbtype.DataType) error {
-	return t.insert(prefix, recordTypeData, t.inserter, false, noNodeIndex, value)
+	return t.insert(
+		prefix,
+		recordTypeData,
+		insertResolver{pure: t.inserter},
+		noNodeIndex,
+		value,
+	)
 }
 
 // InsertFunc will insert the output of the function passed to it. The arguments
@@ -378,22 +367,18 @@ func (t *Tree) Insert(prefix netip.Prefix, value mmdbtype.DataType) error {
 // inserter function should return the mmdbtype.DataType to be inserted. In all
 // cases, a nil value means an empty record.
 //
-// You must never modify either value argument passed to the function, as
-// values may be shared with other records. If you want a copy of the
-// mmdbtype.DataType to modify, call the Copy method on it, which will make a
-// deep copy. This isn't done automatically before calling the function, as not
-// all functions require the record to be copied and there is a non-trivial
-// performance impact.
+// inserter.Func documents the rules the function must follow, including which
+// values it may modify. The tree does not copy a value before the call, as not
+// every function needs a copy and copying costs real time.
 //
-// The function is called separately for every covered record. Any
-// non-nil value it returns becomes tree-owned and must not be modified after the
-// function returns. A nil insertFunc returns an error. If the function
-// returns an error partway through the covered records, the call returns the
-// error but the records already visited keep their new values. A failure
-// before any result is installed leaves values, record boundaries, and lookups
-// logically unchanged. Internal representation and arena allocation are not
-// restored. After a partial success, installed equal values may coalesce, so a
-// retry can observe merged records.
+// The function is called separately for every covered record. A nil insertFunc
+// returns an error. If the function returns an error partway through the
+// covered records, the call returns the error but the records already visited
+// keep their new values. A failure before any result is installed leaves
+// values, record boundaries, and lookups logically unchanged. Internal
+// representation and arena allocation are not restored. After a partial
+// success, installed equal values may coalesce, so a retry can observe merged
+// records.
 //
 // This is not safe to call from multiple threads.
 func (t *Tree) InsertFunc(
@@ -404,34 +389,54 @@ func (t *Tree) InsertFunc(
 	if insertFunc == nil {
 		return errNilInserterFunc
 	}
-	return t.insert(prefix, recordTypeData, insertFunc, false, noNodeIndex, value)
+	return t.insert(
+		prefix,
+		recordTypeData,
+		insertResolver{withMetadata: insertFunc},
+		noNodeIndex,
+		value,
+	)
 }
 
-// InsertPureFunc is like InsertFunc, but the function's result and error must
-// depend only on its arguments. It must not depend on invocation count, order,
-// or external mutable state. Repeated argument pairs may be memoized during the
-// insert, and a non-nil result may be shared by multiple records. A nil
-// insertFunc returns an error. It supplies the zero inserter.Metadata because
-// the memo is keyed by the existing value alone; varying metadata would make
-// that memo unsound.
+// InsertPureFunc inserts the output of a function that receives the existing
+// and new values but no insertion metadata. The function's result and error
+// must depend only on its arguments. It must not depend on invocation count,
+// order, or external mutable state. Repeated argument pairs may be memoized
+// during the insert, and a non-nil result may be shared by multiple records. A
+// nil pureFunc returns an error. The value ownership and partial-error rules
+// are the same as for InsertFunc.
 //
 // This is not safe to call from multiple threads.
 func (t *Tree) InsertPureFunc(
 	prefix netip.Prefix,
 	value mmdbtype.DataType,
-	insertFunc inserter.Func,
+	pureFunc inserter.PureFunc,
 ) error {
-	if insertFunc == nil {
+	if pureFunc == nil {
 		return errNilInserterFunc
 	}
-	return t.insert(prefix, recordTypeData, insertFunc, true, noNodeIndex, value)
+	return t.insert(
+		prefix,
+		recordTypeData,
+		insertResolver{pure: pureFunc},
+		noNodeIndex,
+		value,
+	)
+}
+
+type insertResolver struct {
+	withMetadata inserter.Func
+	pure         inserter.PureFunc
+}
+
+func (r insertResolver) hasFunc() bool {
+	return r.withMetadata != nil || r.pure != nil
 }
 
 func (t *Tree) insert(
 	prefix netip.Prefix,
 	recordType recordType,
-	insertFunc inserter.Func,
-	inserterPure bool,
+	resolver insertResolver,
 	node nodeIndex,
 	value mmdbtype.DataType,
 ) error {
@@ -450,7 +455,7 @@ func (t *Tree) insert(
 			return err
 		}
 	}
-	iRec, err := t.newInsertRecord(recordType, insertFunc, inserterPure, node, value)
+	iRec, err := t.newInsertRecord(recordType, resolver, node, value)
 	if err != nil {
 		return t.finishInsertAudit(err)
 	}
@@ -467,7 +472,7 @@ func (t *Tree) insert(
 func (t *Tree) insertNormalizedRef(
 	prefix netip.Prefix,
 	recordType recordType,
-	insertFunc inserter.Func,
+	pureFunc inserter.PureFunc,
 	node nodeIndex,
 	value valueRef,
 ) error {
@@ -475,8 +480,13 @@ func (t *Tree) insertNormalizedRef(
 		return errors.New("IPv6 prefixes cannot be inserted into an IPv4 tree")
 	}
 	t.valueStore.retain(value)
-	iRec := t.newInsertRecordRef(recordType, insertFunc, false, node, value)
-	if insertFunc != nil {
+	iRec := t.newInsertRecordRef(
+		recordType,
+		insertResolver{pure: pureFunc},
+		node,
+		value,
+	)
+	if pureFunc != nil {
 		iRec.valueView = t.valueStore.materialize(value)
 	}
 	defer iRec.releaseResolved()
@@ -496,7 +506,7 @@ func (t *Tree) insertPrepared(
 	iRec.ip = ip
 	iRec.prefixLen = prefixLen
 	iRec.splitDepth = 0
-	if iRec.inserter != nil && !iRec.inserterPure {
+	if iRec.resolver.withMetadata != nil {
 		iRec.insertedAs4 = prefix.Addr().Is4()
 	}
 	return iRec.insertNode(t.root, 0)
@@ -504,8 +514,7 @@ func (t *Tree) insertPrepared(
 
 func (t *Tree) newInsertRecord(
 	recordType recordType,
-	insertFunc inserter.Func,
-	inserterPure bool,
+	resolver insertResolver,
 	node nodeIndex,
 	value mmdbtype.DataType,
 ) (*insertRecord, error) {
@@ -513,8 +522,8 @@ func (t *Tree) newInsertRecord(
 	// results are interned. Interning the input here would cost a full intern
 	// and a materialized view per insert. Overlay passes decode a fresh value
 	// per source network, so that cost would buy nothing there.
-	if insertFunc != nil {
-		iRec := t.newInsertRecordRef(recordType, insertFunc, inserterPure, node, nilValueRef)
+	if resolver.hasFunc() {
+		iRec := t.newInsertRecordRef(recordType, resolver, node, nilValueRef)
 		iRec.valueView = value
 		return iRec, nil
 	}
@@ -526,7 +535,7 @@ func (t *Tree) newInsertRecord(
 			return nil, err
 		}
 	}
-	iRec := t.newInsertRecordRef(recordType, insertFunc, inserterPure, node, ref)
+	iRec := t.newInsertRecordRef(recordType, resolver, node, ref)
 	iRec.callerValue = value
 	return iRec, nil
 }
@@ -535,15 +544,13 @@ func (t *Tree) newInsertRecord(
 // which releaseResolved releases.
 func (t *Tree) newInsertRecordRef(
 	recordType recordType,
-	insertFunc inserter.Func,
-	inserterPure bool,
+	resolver insertResolver,
 	node nodeIndex,
 	ref valueRef,
 ) *insertRecord {
 	return &insertRecord{
 		recordType:   recordType,
-		inserter:     insertFunc,
-		inserterPure: inserterPure,
+		resolver:     resolver,
 		insertedNode: node,
 		tree:         t,
 		value:        ref,
@@ -691,7 +698,14 @@ func (t *Tree) InsertRange(
 	end netip.Addr,
 	value mmdbtype.DataType,
 ) error {
-	return t.insertRange(start, end, recordTypeData, t.inserter, false, noNodeIndex, value)
+	return t.insertRange(
+		start,
+		end,
+		recordTypeData,
+		insertResolver{pure: t.inserter},
+		noNodeIndex,
+		value,
+	)
 }
 
 // InsertRangeFunc is the same as InsertFunc, except it will insert all subnets
@@ -709,31 +723,44 @@ func (t *Tree) InsertRangeFunc(
 	if insertFunc == nil {
 		return errNilInserterFunc
 	}
-	return t.insertRange(start, end, recordTypeData, insertFunc, false, noNodeIndex, value)
+	return t.insertRange(
+		start,
+		end,
+		recordTypeData,
+		insertResolver{withMetadata: insertFunc},
+		noNodeIndex,
+		value,
+	)
 }
 
 // InsertRangePureFunc is like InsertPureFunc, except it inserts all subnets
 // within the range of IPs specified by `[start,end]`. Repeated argument pairs
 // may be memoized across the entire range, not just within one of its subnets.
-// It supplies the zero inserter.Metadata. A nil insertFunc returns an error.
+// A nil pureFunc returns an error.
 func (t *Tree) InsertRangePureFunc(
 	start netip.Addr,
 	end netip.Addr,
 	value mmdbtype.DataType,
-	insertFunc inserter.Func,
+	pureFunc inserter.PureFunc,
 ) error {
-	if insertFunc == nil {
+	if pureFunc == nil {
 		return errNilInserterFunc
 	}
-	return t.insertRange(start, end, recordTypeData, insertFunc, true, noNodeIndex, value)
+	return t.insertRange(
+		start,
+		end,
+		recordTypeData,
+		insertResolver{pure: pureFunc},
+		noNodeIndex,
+		value,
+	)
 }
 
 func (t *Tree) insertRange(
 	start netip.Addr,
 	end netip.Addr,
 	recordType recordType,
-	insertFunc inserter.Func,
-	inserterPure bool,
+	resolver insertResolver,
 	node nodeIndex,
 	value mmdbtype.DataType,
 ) error {
@@ -753,7 +780,7 @@ func (t *Tree) insertRange(
 	if !r.IsValid() {
 		return errors.New("start & end IPs did not give valid range")
 	}
-	iRec, err := t.newInsertRecord(recordType, insertFunc, inserterPure, node, value)
+	iRec, err := t.newInsertRecord(recordType, resolver, node, value)
 	if err != nil {
 		return t.finishInsertAudit(err)
 	}
@@ -772,14 +799,13 @@ func (t *Tree) insertRange(
 func (t *Tree) insertStringNetwork(
 	network string,
 	recordType recordType,
-	insertFunc inserter.Func,
 	node nodeIndex,
 ) error {
 	prefix, err := netip.ParsePrefix(network)
 	if err != nil {
 		return fmt.Errorf("parsing network (%s): %w", network, err)
 	}
-	return t.insert(prefix, recordType, insertFunc, false, node, nil)
+	return t.insert(prefix, recordType, insertResolver{}, node, nil)
 }
 
 var ipv4AliasNetworks = []string{
@@ -797,13 +823,13 @@ func (t *Tree) insertIPv4Aliases() error {
 	ipv4RootNode := t.newNode([2]record{})
 
 	// Make ::/96, the IPv4 root, a fixed node.
-	err = t.insert(ipv4Root, recordTypeFixedNode, nil, false, ipv4RootNode, nil)
+	err = t.insert(ipv4Root, recordTypeFixedNode, insertResolver{}, ipv4RootNode, nil)
 	if err != nil {
 		return err
 	}
 
 	for _, network := range ipv4AliasNetworks {
-		err := t.insertStringNetwork(network, recordTypeAlias, nil, ipv4RootNode)
+		err := t.insertStringNetwork(network, recordTypeAlias, ipv4RootNode)
 		if err != nil {
 			return err
 		}
@@ -819,7 +845,7 @@ func (t *Tree) insertReservedNetworks() error {
 	}
 
 	for _, network := range networks {
-		err := t.insertStringNetwork(network, recordTypeReserved, nil, noNodeIndex)
+		err := t.insertStringNetwork(network, recordTypeReserved, noNodeIndex)
 		if err != nil {
 			return err
 		}

--- a/tree.go
+++ b/tree.go
@@ -495,8 +495,11 @@ func (t *Tree) insertPrepared(
 	ip, prefixLen := t.prefixInsertIP(prefix)
 	iRec.ip = ip
 	iRec.prefixLen = prefixLen
-	iRec.network = prefix
-	return iRec.insertNode(t.root, 0, 0)
+	iRec.splitDepth = 0
+	if iRec.inserter != nil && !iRec.inserterPure {
+		iRec.insertedAs4 = prefix.Addr().Is4()
+	}
+	return iRec.insertNode(t.root, 0)
 }
 
 func (t *Tree) newInsertRecord(

--- a/tree.go
+++ b/tree.go
@@ -99,6 +99,11 @@ type Options struct {
 	// The existing value it sees is equal to, but not necessarily the same
 	// object as, the value originally inserted.
 	//
+	// Purity is required, not advisory. An Inserter runs once per distinct
+	// existing value, not once per covered record, so one that counts calls or
+	// reads mutable state gives results that depend on the tree's shape. Pass
+	// such a function to InsertFunc or InsertRangeFunc, which never memoize.
+	//
 	// The partial-failure behavior is the same as InsertFunc's.
 	Inserter inserter.PureFunc
 }

--- a/tree.go
+++ b/tree.go
@@ -371,8 +371,9 @@ func (t *Tree) Insert(prefix netip.Prefix, value mmdbtype.DataType) error {
 // values it may modify. The tree does not copy a value before the call, as not
 // every function needs a copy and copying costs real time.
 //
-// The function is called separately for every covered record. A nil insertFunc
-// returns an error. If the function returns an error partway through the
+// The function is called separately for every covered record, except that a
+// reserved or aliased network inside the inserted network is skipped silently.
+// A nil insertFunc returns an error. If the function returns an error partway through the
 // covered records, the call returns the error but the records already visited
 // keep their new values. A failure before any result is installed leaves
 // values, record boundaries, and lookups logically unchanged. After a partial

--- a/tree.go
+++ b/tree.go
@@ -303,13 +303,7 @@ func Load(path string, opts Options) (*Tree, error) {
 			return nil, err
 		}
 
-		err = tree.insertNormalizedRef(
-			prefix,
-			recordTypeData,
-			tree.inserter,
-			noNodeIndex,
-			value,
-		)
+		err = tree.insertNormalizedRef(prefix, tree.inserter, value)
 		tree.valueStore.release(value)
 		if err != nil {
 			return nil, fmt.Errorf("loading network %s from %s: %w", prefix, path, err)
@@ -480,9 +474,7 @@ func (t *Tree) insert(
 // caller's reference, taking one of its own for the insert.
 func (t *Tree) insertNormalizedRef(
 	prefix netip.Prefix,
-	recordType recordType,
 	pureFunc inserter.PureFunc,
-	node nodeIndex,
 	value valueRef,
 ) error {
 	if t.treeDepth == 32 && !prefix.Addr().Is4() {
@@ -490,9 +482,9 @@ func (t *Tree) insertNormalizedRef(
 	}
 	t.valueStore.retain(value)
 	iRec := t.newInsertRecordRef(
-		recordType,
+		recordTypeData,
 		insertResolver{pure: pureFunc},
-		node,
+		noNodeIndex,
 		value,
 	)
 	if pureFunc != nil {

--- a/tree.go
+++ b/tree.go
@@ -93,7 +93,7 @@ type Options struct {
 	// direct-value fast path. Passing `inserter.Replace` explicitly has the same
 	// behavior but skips that optimization.
 	//
-	// An Inserter must not modify either argument. The existing value is a
+	// An Inserter must not modify either value argument. The existing value is a
 	// shared, read-only view. It is equal to, but not necessarily the same
 	// object as, the value originally inserted. The new value is the value
 	// passed to the insert call, or a shared view of the decoded record
@@ -102,10 +102,20 @@ type Options struct {
 	// every covered record. Any non-nil returned value becomes tree-owned and
 	// must not be modified after return.
 	//
+	// The function also receives metadata for the insertion and for the record
+	// containing the existing value as it stood before the current insertion
+	// began mutating it. During Load, InsertedNetwork is the normalized network
+	// of the source record. During a range insert, it is each individual prefix
+	// into which the range decomposes.
+	//
 	// Only direct inserts and inserter results are validated, so the function
 	// can receive an unsupported input value, such as a raw mmdbtype.Pointer,
-	// and must replace or discard it. If the function fails partway through
-	// the covered records, the records already visited keep their new values.
+	// and must replace or discard it. If the function returns an error partway
+	// through the covered records, the records already visited keep their new
+	// values. A failure before any result is installed leaves values, record
+	// extents, and lookups logically unchanged, although internal representation
+	// and arena allocation are not restored. After a partial success, installed
+	// equal values may coalesce, so a retry can observe merged extents.
 	Inserter inserter.Func
 }
 
@@ -239,8 +249,9 @@ func metadataDimension(name string, value uint) (int, error) {
 // stored value.
 // During the load, a cache holds one reference per distinct offset in the
 // source data section. Load releases the cache before it returns. A
-// non-nil Options.Inserter also receives a materialized view of each
-// decoded record. The inserter must treat its arguments as immutable and must
+// non-nil Options.Inserter also receives a materialized view of each decoded
+// record and metadata whose InsertedNetwork is the normalized source-record
+// network. The inserter must treat its value arguments as immutable and must
 // copy a value before modifying it.
 func Load(path string, opts Options) (*Tree, error) {
 	db, err := maxminddb.Open(path)
@@ -362,23 +373,27 @@ func (t *Tree) Insert(prefix netip.Prefix, value mmdbtype.DataType) error {
 }
 
 // InsertFunc will insert the output of the function passed to it. The arguments
-// passed to the function are the existing value in the record and the new value
-// passed to InsertFunc. The inserter function should return the
-// mmdbtype.DataType to be inserted. In all cases, a nil value means an empty
-// record.
+// passed to the function are the existing value in the record, the new value
+// passed to InsertFunc, and metadata for the insertion and existing record. The
+// inserter function should return the mmdbtype.DataType to be inserted. In all
+// cases, a nil value means an empty record.
 //
-// You must never modify arguments passed to the function as values may be
-// shared with other records. If you want a copy of the mmdbtype.DataType to
-// modify, call the Copy method on it, which will make a deep copy. This isn't
-// done automatically before calling the function as not all functions will
-// require the record to be copied and there is a non-trivial performance
-// impact.
+// You must never modify either value argument passed to the function, as
+// values may be shared with other records. If you want a copy of the
+// mmdbtype.DataType to modify, call the Copy method on it, which will make a
+// deep copy. This isn't done automatically before calling the function, as not
+// all functions require the record to be copied and there is a non-trivial
+// performance impact.
 //
 // The function is called separately for every covered record. Any
 // non-nil value it returns becomes tree-owned and must not be modified after the
-// function returns. A nil insertFunc returns an error. If the function fails
-// partway through the covered records, the call returns the error but the
-// records already visited keep their new values.
+// function returns. A nil insertFunc returns an error. If the function
+// returns an error partway through the covered records, the call returns the
+// error but the records already visited keep their new values. A failure
+// before any result is installed leaves values, record boundaries, and lookups
+// logically unchanged. Internal representation and arena allocation are not
+// restored. After a partial success, installed equal values may coalesce, so a
+// retry can observe merged records.
 //
 // This is not safe to call from multiple threads.
 func (t *Tree) InsertFunc(
@@ -396,7 +411,9 @@ func (t *Tree) InsertFunc(
 // depend only on its arguments. It must not depend on invocation count, order,
 // or external mutable state. Repeated argument pairs may be memoized during the
 // insert, and a non-nil result may be shared by multiple records. A nil
-// insertFunc returns an error.
+// insertFunc returns an error. It supplies the zero inserter.Metadata because
+// the memo is keyed by the existing value alone; varying metadata would make
+// that memo unsound.
 //
 // This is not safe to call from multiple threads.
 func (t *Tree) InsertPureFunc(
@@ -675,8 +692,11 @@ func (t *Tree) InsertRange(
 }
 
 // InsertRangeFunc is the same as InsertFunc, except it will insert all subnets
-// within the range of IPs specified by `[start,end]`. A nil insertFunc returns
-// an error.
+// within the range of IPs specified by `[start,end]`. The metadata's
+// InsertedNetwork is the individual subnet being inserted, not the whole
+// range. Subnets are inserted sequentially, so metadata for a later subnet
+// reflects changes made by earlier subnets in the same call. A nil insertFunc
+// returns an error.
 func (t *Tree) InsertRangeFunc(
 	start netip.Addr,
 	end netip.Addr,
@@ -692,7 +712,7 @@ func (t *Tree) InsertRangeFunc(
 // InsertRangePureFunc is like InsertPureFunc, except it inserts all subnets
 // within the range of IPs specified by `[start,end]`. Repeated argument pairs
 // may be memoized across the entire range, not just within one of its subnets.
-// A nil insertFunc returns an error.
+// It supplies the zero inserter.Metadata. A nil insertFunc returns an error.
 func (t *Tree) InsertRangePureFunc(
 	start netip.Addr,
 	end netip.Addr,

--- a/tree.go
+++ b/tree.go
@@ -429,6 +429,10 @@ func (t *Tree) InsertPureFunc(
 	)
 }
 
+// insertResolver carries the callback for one insert. At most one field is
+// non-nil: both nil for a direct value, an alias, or a reserved insert, and
+// otherwise whichever kind the caller chose. resolve reads pure first, so a
+// value with both set would silently ignore withMetadata.
 type insertResolver struct {
 	withMetadata inserter.Func
 	pure         inserter.PureFunc

--- a/tree.go
+++ b/tree.go
@@ -375,10 +375,14 @@ func (t *Tree) Insert(prefix netip.Prefix, value mmdbtype.DataType) error {
 // returns an error. If the function returns an error partway through the
 // covered records, the call returns the error but the records already visited
 // keep their new values. A failure before any result is installed leaves
-// values, record boundaries, and lookups logically unchanged. Internal
-// representation and arena allocation are not restored. After a partial
-// success, installed equal values may coalesce, so a retry can observe merged
-// records.
+// values, record boundaries, and lookups logically unchanged. After a partial
+// success, installed equal values, and records that become equally empty, may
+// coalesce, so a retry can observe merged records.
+//
+// A failed insert does not shrink the tree back. Splitting a record to reach
+// the inserted network allocates nodes, and the unwinding merge restores the
+// record boundaries without reclaiming them, so a caller that retries a failing
+// insert many times grows the node arena each time.
 //
 // This is not safe to call from multiple threads.
 func (t *Tree) InsertFunc(

--- a/tree.go
+++ b/tree.go
@@ -478,7 +478,8 @@ func (t *Tree) insertPrepared(
 	ip, prefixLen := t.prefixInsertIP(prefix)
 	iRec.ip = ip
 	iRec.prefixLen = prefixLen
-	return iRec.insertNode(t.root, 0)
+	iRec.network = prefix
+	return iRec.insertNode(t.root, 0, 0)
 }
 
 func (t *Tree) newInsertRecord(

--- a/tree_benchmark_test.go
+++ b/tree_benchmark_test.go
@@ -226,7 +226,7 @@ func BenchmarkEnterpriseLoadThenOverlay(b *testing.B) {
 		}
 		for _, layer := range overlays {
 			for _, spec := range layer {
-				if err := tree.InsertFunc(
+				if err := tree.InsertPureFunc(
 					spec.network,
 					spec.value.Copy(),
 					inserter.DeepMerge,
@@ -248,28 +248,24 @@ func BenchmarkTreeInsertMetadataOverlayPasses(b *testing.B) {
 	plainBase, provenanceBase, plainOverlays, provenanceOverlays := metadataOverlayBenchmarkSpecs(
 		2_048,
 	)
-	plainSource := writeBenchmarkSource(b, plainBase, "metadata-overlay")
-	provenanceSource := writeBenchmarkSource(b, provenanceBase, "metadata-overlay")
+	plainSource := writeBenchmarkSource(b, plainBase)
+	provenanceSource := writeBenchmarkSource(b, provenanceBase)
 
-	metadataOutput := runMetadataOverlayBenchmark(b, plainSource, plainOverlays)
-	provenanceOutput := runProvenanceOverlayBenchmark(b, provenanceSource, provenanceOverlays)
-	if !bytes.Equal(metadataOutput, provenanceOutput) {
+	metadataTree := loadMetadataFixture(b, plainSource)
+	applyMetadataOverlays(b, metadataTree, plainOverlays)
+	provenanceTree := loadMetadataFixture(b, provenanceSource)
+	applyProvenanceOverlays(b, provenanceTree, provenanceOverlays)
+	if !bytes.Equal(writeTreeBytes(b, metadataTree), writeTreeBytes(b, provenanceTree)) {
 		b.Fatal("metadata and provenance benchmark fixtures produced different databases")
 	}
 
 	b.Run("metadata", func(b *testing.B) {
 		b.ReportAllocs()
 		for b.Loop() {
-			tree := loadBenchmarkSource(b, plainSource)
-			for _, spec := range plainOverlays {
-				if err := tree.InsertFunc(
-					spec.network,
-					spec.value,
-					metadataSpecificityInserter,
-				); err != nil {
-					b.Fatal(err)
-				}
-			}
+			b.StopTimer()
+			tree := loadMetadataFixture(b, plainSource)
+			b.StartTimer()
+			applyMetadataOverlays(b, tree, plainOverlays)
 		}
 		b.ReportMetric(float64(len(plainOverlays)), "overlays/op")
 	})
@@ -277,23 +273,10 @@ func BenchmarkTreeInsertMetadataOverlayPasses(b *testing.B) {
 	b.Run("sort-provenance-strip", func(b *testing.B) {
 		b.ReportAllocs()
 		for b.Loop() {
-			tree := loadBenchmarkSource(b, provenanceSource)
-			overlays := slices.Clone(provenanceOverlays)
-			slices.SortFunc(overlays, func(left, right benchmarkInsertSpec) int {
-				return right.network.Bits() - left.network.Bits()
-			})
-			for _, spec := range overlays {
-				if err := tree.InsertFunc(
-					spec.network,
-					spec.value,
-					provenanceSpecificityInserter,
-				); err != nil {
-					b.Fatal(err)
-				}
-			}
-			if err := stripBenchmarkProvenance(tree); err != nil {
-				b.Fatal(err)
-			}
+			b.StopTimer()
+			tree := loadMetadataFixture(b, provenanceSource)
+			b.StartTimer()
+			applyProvenanceOverlays(b, tree, provenanceOverlays)
 		}
 		b.ReportMetric(float64(len(provenanceOverlays)), "overlays/op")
 	})
@@ -363,12 +346,11 @@ func metadataOverlayBenchmarkSpecs(groupCount int) (
 func writeBenchmarkSource(
 	b *testing.B,
 	specs []benchmarkInsertSpec,
-	databaseType string,
 ) string {
 	b.Helper()
 	tree, err := New(Options{
 		BuildEpoch:              1,
-		DatabaseType:            databaseType,
+		DatabaseType:            "metadata-overlay",
 		Description:             map[string]string{"en": "Metadata overlay benchmark"},
 		IPVersion:               4,
 		IncludeReservedNetworks: true,
@@ -395,45 +377,33 @@ func writeBenchmarkSource(
 	return file.Name()
 }
 
-func loadBenchmarkSource(b *testing.B, path string) *Tree {
-	b.Helper()
-	tree, err := Load(path, Options{
-		BuildEpoch:              1,
-		IPVersion:               4,
-		IncludeReservedNetworks: true,
-	})
-	if err != nil {
-		b.Fatal(err)
-	}
-	return tree
-}
-
-func runMetadataOverlayBenchmark(
-	b *testing.B,
-	path string,
+// applyMetadataOverlays inserts the overlays in one unsorted pass, letting the
+// inserter compare the inserted network with the existing record.
+func applyMetadataOverlays(
+	tb testing.TB,
+	tree *Tree,
 	overlays []benchmarkInsertSpec,
-) []byte {
-	b.Helper()
-	tree := loadBenchmarkSource(b, path)
+) {
+	tb.Helper()
 	for _, spec := range overlays {
 		if err := tree.InsertFunc(
 			spec.network,
 			spec.value,
 			metadataSpecificityInserter,
 		); err != nil {
-			b.Fatal(err)
+			tb.Fatal(err)
 		}
 	}
-	return benchmarkTreeBytes(b, tree)
 }
 
-func runProvenanceOverlayBenchmark(
-	b *testing.B,
-	path string,
+// applyProvenanceOverlays is the pre-metadata equivalent: sort by prefix
+// length, compare against a prefix length carried in the value, then strip it.
+func applyProvenanceOverlays(
+	tb testing.TB,
+	tree *Tree,
 	overlays []benchmarkInsertSpec,
-) []byte {
-	b.Helper()
-	tree := loadBenchmarkSource(b, path)
+) {
+	tb.Helper()
 	sorted := slices.Clone(overlays)
 	slices.SortFunc(sorted, func(left, right benchmarkInsertSpec) int {
 		return right.network.Bits() - left.network.Bits()
@@ -444,37 +414,10 @@ func runProvenanceOverlayBenchmark(
 			spec.value,
 			provenanceSpecificityInserter,
 		); err != nil {
-			b.Fatal(err)
+			tb.Fatal(err)
 		}
 	}
-	if err := stripBenchmarkProvenance(tree); err != nil {
-		b.Fatal(err)
-	}
-	return benchmarkTreeBytes(b, tree)
-}
-
-func stripBenchmarkProvenance(tree *Tree) error {
-	return tree.InsertFunc(
-		netip.MustParsePrefix("0.0.0.0/0"),
-		nil,
-		func(existingValue, _ mmdbtype.DataType, _ inserter.Metadata) (mmdbtype.DataType, error) {
-			if existingValue == nil {
-				return nil, nil
-			}
-			value := existingValue.Copy().(mmdbtype.Map)
-			delete(value, provenancePrefixLengthKey)
-			return value, nil
-		},
-	)
-}
-
-func benchmarkTreeBytes(b *testing.B, tree *Tree) []byte {
-	b.Helper()
-	var output bytes.Buffer
-	if _, err := tree.WriteTo(&output); err != nil {
-		b.Fatal(err)
-	}
-	return output.Bytes()
+	stripProvenance(tb, tree)
 }
 
 func enterpriseBenchmarkLayers(
@@ -517,16 +460,16 @@ func enterpriseBenchmarkLayers(
 func reportOverlappingBenchmarkShape(
 	b *testing.B,
 	specs []benchmarkInsertSpec,
-	insertFunc inserter.Func,
+	pureFunc inserter.PureFunc,
 ) {
 	b.Helper()
 
 	tree := newBenchmarkTree(b)
-	if insertFunc == nil {
+	if pureFunc == nil {
 		insertBenchmarkSpecs(b, tree, specs)
 	} else {
 		for _, spec := range specs {
-			if err := tree.InsertPureFunc(spec.network, spec.value, insertFunc); err != nil {
+			if err := tree.InsertPureFunc(spec.network, spec.value, pureFunc); err != nil {
 				b.Fatal(err)
 			}
 		}

--- a/tree_benchmark_test.go
+++ b/tree_benchmark_test.go
@@ -2,10 +2,10 @@ package mmdbwriter
 
 import (
 	"bytes"
+	"encoding/binary"
 	"fmt"
 	"io"
 	"net/netip"
-	"os"
 	"slices"
 	"testing"
 
@@ -160,23 +160,12 @@ func BenchmarkTreeLoadOverlappingPasses(b *testing.B) {
 	tree := newBenchmarkTree(b)
 	insertBenchmarkSpecs(b, tree, specs)
 
-	file, err := os.CreateTemp(b.TempDir(), "mmdbwriter-benchmark-*.mmdb")
-	if err != nil {
-		b.Fatal(err)
-	}
-
-	_, err = tree.WriteTo(file)
-	if err != nil {
-		b.Fatal(err)
-	}
-	if err := file.Close(); err != nil {
-		b.Fatal(err)
-	}
+	path := writeTempDB(b, tree)
 
 	b.ReportAllocs()
 	for b.Loop() {
 		loadedTree, err := Load(
-			file.Name(),
+			path,
 			Options{
 				IncludeReservedNetworks: true,
 			},
@@ -207,20 +196,11 @@ func BenchmarkEnterpriseLoadThenOverlay(b *testing.B) {
 			b.Fatal(err)
 		}
 	}
-	file, err := os.CreateTemp(b.TempDir(), "mmdbwriter-enterprise-*.mmdb")
-	if err != nil {
-		b.Fatal(err)
-	}
-	if _, err := source.WriteTo(file); err != nil {
-		b.Fatal(err)
-	}
-	if err := file.Close(); err != nil {
-		b.Fatal(err)
-	}
+	path := writeTempDB(b, source)
 
 	b.ReportAllocs()
 	for b.Loop() {
-		tree, err := Load(file.Name(), Options{IncludeReservedNetworks: true})
+		tree, err := Load(path, Options{IncludeReservedNetworks: true})
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -343,6 +323,12 @@ func metadataOverlayBenchmarkSpecs(groupCount int) (
 	return plainBase, provenanceBase, plainOverlays, provenanceOverlays
 }
 
+func ipv4Addr(value uint32) netip.Addr {
+	var address [4]byte
+	binary.BigEndian.PutUint32(address[:], value)
+	return netip.AddrFrom4(address)
+}
+
 func writeBenchmarkSource(
 	b *testing.B,
 	specs []benchmarkInsertSpec,
@@ -364,17 +350,7 @@ func writeBenchmarkSource(
 			b.Fatal(err)
 		}
 	}
-	file, err := os.CreateTemp(b.TempDir(), "mmdbwriter-metadata-overlay-*.mmdb")
-	if err != nil {
-		b.Fatal(err)
-	}
-	if _, err := tree.WriteTo(file); err != nil {
-		b.Fatal(err)
-	}
-	if err := file.Close(); err != nil {
-		b.Fatal(err)
-	}
-	return file.Name()
+	return writeTempDB(b, tree)
 }
 
 // applyMetadataOverlays inserts the overlays in one unsorted pass, letting the

--- a/tree_benchmark_test.go
+++ b/tree_benchmark_test.go
@@ -1,10 +1,12 @@
 package mmdbwriter
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"net/netip"
 	"os"
+	"slices"
 	"testing"
 
 	"github.com/maxmind/mmdbwriter/v2/inserter"
@@ -237,6 +239,242 @@ func BenchmarkEnterpriseLoadThenOverlay(b *testing.B) {
 
 	b.ReportMetric(float64(len(base)), "networks/op")
 	b.ReportMetric(float64(len(overlays)), "overlays/op")
+}
+
+// BenchmarkTreeInsertMetadataOverlayPasses compares a single unsorted metadata
+// overlay with the equivalent sort, provenance comparison, and strip pass.
+// The fixture has disjoint overlays that exercise both comparator outcomes.
+func BenchmarkTreeInsertMetadataOverlayPasses(b *testing.B) {
+	plainBase, provenanceBase, plainOverlays, provenanceOverlays := metadataOverlayBenchmarkSpecs(
+		2_048,
+	)
+	plainSource := writeBenchmarkSource(b, plainBase, "metadata-overlay")
+	provenanceSource := writeBenchmarkSource(b, provenanceBase, "metadata-overlay")
+
+	metadataOutput := runMetadataOverlayBenchmark(b, plainSource, plainOverlays)
+	provenanceOutput := runProvenanceOverlayBenchmark(b, provenanceSource, provenanceOverlays)
+	if !bytes.Equal(metadataOutput, provenanceOutput) {
+		b.Fatal("metadata and provenance benchmark fixtures produced different databases")
+	}
+
+	b.Run("metadata", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			tree := loadBenchmarkSource(b, plainSource)
+			for _, spec := range plainOverlays {
+				if err := tree.InsertFunc(
+					spec.network,
+					spec.value,
+					metadataSpecificityInserter,
+				); err != nil {
+					b.Fatal(err)
+				}
+			}
+		}
+		b.ReportMetric(float64(len(plainOverlays)), "overlays/op")
+	})
+
+	b.Run("sort-provenance-strip", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			tree := loadBenchmarkSource(b, provenanceSource)
+			overlays := slices.Clone(provenanceOverlays)
+			slices.SortFunc(overlays, func(left, right benchmarkInsertSpec) int {
+				return right.network.Bits() - left.network.Bits()
+			})
+			for _, spec := range overlays {
+				if err := tree.InsertFunc(
+					spec.network,
+					spec.value,
+					provenanceSpecificityInserter,
+				); err != nil {
+					b.Fatal(err)
+				}
+			}
+			if err := stripBenchmarkProvenance(tree); err != nil {
+				b.Fatal(err)
+			}
+		}
+		b.ReportMetric(float64(len(provenanceOverlays)), "overlays/op")
+	})
+}
+
+func metadataOverlayBenchmarkSpecs(groupCount int) (
+	plainBase,
+	provenanceBase,
+	plainOverlays,
+	provenanceOverlays []benchmarkInsertSpec,
+) {
+	plainBase = make([]benchmarkInsertSpec, 0, groupCount*3)
+	provenanceBase = make([]benchmarkInsertSpec, 0, groupCount*3)
+	plainOverlays = make([]benchmarkInsertSpec, 0, groupCount*2)
+	provenanceOverlays = make([]benchmarkInsertSpec, 0, groupCount*2)
+	for group := range groupCount {
+		start := uint32(0x01000000 + group*4) // 1.0.0.0 and upward.
+		for child := range 2 {
+			prefix := netip.PrefixFrom(ipv4Addr(start+uint32(child)), 32)
+			name := mmdbtype.String(fmt.Sprintf("base-specific-%d-%d", group, child))
+			plainBase = append(plainBase, benchmarkInsertSpec{
+				network: prefix,
+				value:   mmdbtype.Map{"name": name},
+			})
+			provenanceBase = append(provenanceBase, benchmarkInsertSpec{
+				network: prefix,
+				value:   provenanceValue(name, 32),
+			})
+		}
+
+		wideBasePrefix := netip.PrefixFrom(ipv4Addr(start+2), 31)
+		wideBaseName := mmdbtype.String(fmt.Sprintf("base-wide-%d", group))
+		plainBase = append(plainBase, benchmarkInsertSpec{
+			network: wideBasePrefix,
+			value:   mmdbtype.Map{"name": wideBaseName},
+		})
+		provenanceBase = append(provenanceBase, benchmarkInsertSpec{
+			network: wideBasePrefix,
+			value:   provenanceValue(wideBaseName, 31),
+		})
+
+		wideOverlayPrefix := netip.PrefixFrom(ipv4Addr(start), 31)
+		wideOverlayName := mmdbtype.String(fmt.Sprintf("overlay-wide-%d", group))
+		plainOverlays = append(plainOverlays, benchmarkInsertSpec{
+			network: wideOverlayPrefix,
+			value:   mmdbtype.Map{"name": wideOverlayName},
+		})
+		provenanceOverlays = append(provenanceOverlays, benchmarkInsertSpec{
+			network: wideOverlayPrefix,
+			value:   provenanceValue(wideOverlayName, 31),
+		})
+
+		specificOverlayPrefix := netip.PrefixFrom(ipv4Addr(start+2), 32)
+		specificOverlayName := mmdbtype.String(fmt.Sprintf("overlay-specific-%d", group))
+		plainOverlays = append(plainOverlays, benchmarkInsertSpec{
+			network: specificOverlayPrefix,
+			value:   mmdbtype.Map{"name": specificOverlayName},
+		})
+		provenanceOverlays = append(provenanceOverlays, benchmarkInsertSpec{
+			network: specificOverlayPrefix,
+			value:   provenanceValue(specificOverlayName, 32),
+		})
+	}
+	return plainBase, provenanceBase, plainOverlays, provenanceOverlays
+}
+
+func writeBenchmarkSource(
+	b *testing.B,
+	specs []benchmarkInsertSpec,
+	databaseType string,
+) string {
+	b.Helper()
+	tree, err := New(Options{
+		BuildEpoch:              1,
+		DatabaseType:            databaseType,
+		Description:             map[string]string{"en": "Metadata overlay benchmark"},
+		IPVersion:               4,
+		IncludeReservedNetworks: true,
+		RecordSize:              24,
+	})
+	if err != nil {
+		b.Fatal(err)
+	}
+	for _, spec := range specs {
+		if err := tree.Insert(spec.network, spec.value); err != nil {
+			b.Fatal(err)
+		}
+	}
+	file, err := os.CreateTemp(b.TempDir(), "mmdbwriter-metadata-overlay-*.mmdb")
+	if err != nil {
+		b.Fatal(err)
+	}
+	if _, err := tree.WriteTo(file); err != nil {
+		b.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		b.Fatal(err)
+	}
+	return file.Name()
+}
+
+func loadBenchmarkSource(b *testing.B, path string) *Tree {
+	b.Helper()
+	tree, err := Load(path, Options{
+		BuildEpoch:              1,
+		IPVersion:               4,
+		IncludeReservedNetworks: true,
+	})
+	if err != nil {
+		b.Fatal(err)
+	}
+	return tree
+}
+
+func runMetadataOverlayBenchmark(
+	b *testing.B,
+	path string,
+	overlays []benchmarkInsertSpec,
+) []byte {
+	b.Helper()
+	tree := loadBenchmarkSource(b, path)
+	for _, spec := range overlays {
+		if err := tree.InsertFunc(
+			spec.network,
+			spec.value,
+			metadataSpecificityInserter,
+		); err != nil {
+			b.Fatal(err)
+		}
+	}
+	return benchmarkTreeBytes(b, tree)
+}
+
+func runProvenanceOverlayBenchmark(
+	b *testing.B,
+	path string,
+	overlays []benchmarkInsertSpec,
+) []byte {
+	b.Helper()
+	tree := loadBenchmarkSource(b, path)
+	sorted := slices.Clone(overlays)
+	slices.SortFunc(sorted, func(left, right benchmarkInsertSpec) int {
+		return right.network.Bits() - left.network.Bits()
+	})
+	for _, spec := range sorted {
+		if err := tree.InsertFunc(
+			spec.network,
+			spec.value,
+			provenanceSpecificityInserter,
+		); err != nil {
+			b.Fatal(err)
+		}
+	}
+	if err := stripBenchmarkProvenance(tree); err != nil {
+		b.Fatal(err)
+	}
+	return benchmarkTreeBytes(b, tree)
+}
+
+func stripBenchmarkProvenance(tree *Tree) error {
+	return tree.InsertFunc(
+		netip.MustParsePrefix("0.0.0.0/0"),
+		nil,
+		func(existingValue, _ mmdbtype.DataType, _ inserter.Metadata) (mmdbtype.DataType, error) {
+			if existingValue == nil {
+				return nil, nil
+			}
+			value := existingValue.Copy().(mmdbtype.Map)
+			delete(value, provenancePrefixLengthKey)
+			return value, nil
+		},
+	)
+}
+
+func benchmarkTreeBytes(b *testing.B, tree *Tree) []byte {
+	b.Helper()
+	var output bytes.Buffer
+	if _, err := tree.WriteTo(&output); err != nil {
+		b.Fatal(err)
+	}
+	return output.Bytes()
 }
 
 func enterpriseBenchmarkLayers(

--- a/tree_test.go
+++ b/tree_test.go
@@ -165,7 +165,7 @@ func TestPanickingInserterReleasesItsReferences(t *testing.T) {
 		tree.InsertPureFunc(
 			netip.MustParsePrefix("1.0.0.0/24"),
 			mmdbtype.Map{"name": mmdbtype.String("new")},
-			func(existing, _ mmdbtype.DataType) (mmdbtype.DataType, error) {
+			func(existing, _ mmdbtype.DataType, _ inserter.Metadata) (mmdbtype.DataType, error) {
 				calls++
 				if calls == 2 {
 					panic("inserter failure")
@@ -203,7 +203,7 @@ func TestPanickingRangeInserterReleasesItsReferences(t *testing.T) {
 			netip.MustParseAddr("1.0.0.0"),
 			netip.MustParseAddr("1.0.0.255"),
 			mmdbtype.Map{"name": mmdbtype.String("new")},
-			func(existing, _ mmdbtype.DataType) (mmdbtype.DataType, error) {
+			func(existing, _ mmdbtype.DataType, _ inserter.Metadata) (mmdbtype.DataType, error) {
 				calls++
 				if calls == 2 {
 					panic("inserter failure")
@@ -367,7 +367,7 @@ func TestTreeInsertPureFuncMemoizesDistinctExistingValues(t *testing.T) {
 	err = tree.InsertPureFunc(
 		netip.MustParsePrefix("1.2.3.0/24"),
 		mmdbtype.String("new"),
-		func(existing, newValue mmdbtype.DataType) (mmdbtype.DataType, error) {
+		func(existing, newValue mmdbtype.DataType, _ inserter.Metadata) (mmdbtype.DataType, error) {
 			calls[existing.(mmdbtype.String)]++
 			return newValue, nil
 		},
@@ -413,7 +413,7 @@ func TestTreeInsertPureFuncReleasesMemoAfterPartialError(t *testing.T) {
 	err = tree.InsertPureFunc(
 		netip.MustParsePrefix("1.2.3.0/24"),
 		mmdbtype.String("new"),
-		func(existing, _ mmdbtype.DataType) (mmdbtype.DataType, error) {
+		func(existing, _ mmdbtype.DataType, _ inserter.Metadata) (mmdbtype.DataType, error) {
 			if existing == mmdbtype.String("second") {
 				return nil, insertErr
 			}
@@ -451,7 +451,7 @@ func TestTreeInsertFuncEvaluatesOrdinaryFuncForEveryRecord(t *testing.T) {
 	err = tree.InsertFunc(
 		netip.MustParsePrefix("1.2.3.0/24"),
 		mmdbtype.String("new"),
-		inserter.Func(func(_, _ mmdbtype.DataType) (mmdbtype.DataType, error) {
+		inserter.Func(func(_, _ mmdbtype.DataType, _ inserter.Metadata) (mmdbtype.DataType, error) {
 			calls++
 			//nolint:gosec // calls is bounded by the four covered records
 			return mmdbtype.Uint32(calls), nil
@@ -541,7 +541,7 @@ func TestTreeInsertFuncErrorDoesNotMutateEmptySiblingRecord(t *testing.T) {
 	err = tree.InsertFunc(
 		netip.MustParsePrefix("1.2.2.0/24"),
 		mmdbtype.String("value"),
-		inserter.Func(func(_, _ mmdbtype.DataType) (mmdbtype.DataType, error) {
+		inserter.Func(func(_, _ mmdbtype.DataType, _ inserter.Metadata) (mmdbtype.DataType, error) {
 			return nil, insertErr
 		}),
 	)
@@ -572,7 +572,7 @@ func TestTreeInsertFuncErrorLeavesExistingRecordUnchanged(t *testing.T) {
 	err = tree.InsertFunc(
 		prefix,
 		mmdbtype.Map{"extra": mmdbtype.String("value")},
-		inserter.Func(func(_, _ mmdbtype.DataType) (mmdbtype.DataType, error) {
+		inserter.Func(func(_, _ mmdbtype.DataType, _ inserter.Metadata) (mmdbtype.DataType, error) {
 			return nil, insertErr
 		}),
 	)
@@ -626,9 +626,11 @@ func TestTreeInsertFuncReturnsErrorForNilUint128Result(t *testing.T) {
 			err = tree.InsertFunc(
 				prefix,
 				nil,
-				inserter.Func(func(_, _ mmdbtype.DataType) (mmdbtype.DataType, error) {
-					return test.result(nilUint128), nil
-				}),
+				inserter.Func(
+					func(_, _ mmdbtype.DataType, _ inserter.Metadata) (mmdbtype.DataType, error) {
+						return test.result(nilUint128), nil
+					},
+				),
 			)
 			require.EqualError(t, err, test.expectedError)
 
@@ -873,7 +875,7 @@ func TestTreeInsertRangePureFuncMemoizesAcrossSubnets(t *testing.T) {
 		netip.MustParseAddr("1.2.3.1"),
 		netip.MustParseAddr("1.2.3.254"),
 		newValue,
-		func(existing, replacement mmdbtype.DataType) (mmdbtype.DataType, error) {
+		func(existing, replacement mmdbtype.DataType, _ inserter.Metadata) (mmdbtype.DataType, error) {
 			calls++
 			assert.Equal(t, oldValue, existing)
 			return replacement, nil
@@ -1106,7 +1108,7 @@ func TestInsertFuncReceivesCallerValueUninterned(t *testing.T) {
 	require.NoError(t, tree.InsertFunc(
 		netip.MustParsePrefix("1.2.3.0/24"),
 		input,
-		func(_, newValue mmdbtype.DataType) (mmdbtype.DataType, error) {
+		func(_, newValue mmdbtype.DataType, _ inserter.Metadata) (mmdbtype.DataType, error) {
 			require.Equal(t, input, newValue)
 			return mmdbtype.String("value"), nil
 		},
@@ -1305,7 +1307,7 @@ func TestInserterResultWithPointerIsRejected(t *testing.T) {
 	err := tree.InsertFunc(
 		netip.MustParsePrefix("1.2.3.0/24"),
 		mmdbtype.String("new"),
-		func(_, _ mmdbtype.DataType) (mmdbtype.DataType, error) {
+		func(_, _ mmdbtype.DataType, _ inserter.Metadata) (mmdbtype.DataType, error) {
 			return mmdbtype.Map{"p": mmdbtype.Pointer(7)}, nil
 		},
 	)
@@ -2146,7 +2148,7 @@ func TestInsertFunc_RemovalAndLaterInsert(t *testing.T) {
 	err = tree.InsertFunc(
 		removedNetwork,
 		nil,
-		inserter.Func(func(v, _ mmdbtype.DataType) (mmdbtype.DataType, error) {
+		inserter.Func(func(v, _ mmdbtype.DataType, _ inserter.Metadata) (mmdbtype.DataType, error) {
 			return v, nil
 		}),
 	)
@@ -2195,7 +2197,7 @@ func TestInsertPureFuncEqualResultKeepsReference(t *testing.T) {
 	require.NoError(t, tree.InsertPureFunc(
 		prefix,
 		mmdbtype.String("value"),
-		func(existingValue, _ mmdbtype.DataType) (mmdbtype.DataType, error) {
+		func(existingValue, _ mmdbtype.DataType, _ inserter.Metadata) (mmdbtype.DataType, error) {
 			return existingValue, nil
 		},
 	))
@@ -2231,7 +2233,7 @@ func TestInsertFuncReleasesRedundantStoredReference(t *testing.T) {
 	require.NoError(t, tree.InsertFunc(
 		prefix,
 		mmdbtype.String("ignored"),
-		func(_, _ mmdbtype.DataType) (mmdbtype.DataType, error) {
+		func(_, _ mmdbtype.DataType, _ inserter.Metadata) (mmdbtype.DataType, error) {
 			return &shared, nil
 		},
 	))

--- a/tree_test.go
+++ b/tree_test.go
@@ -2659,13 +2659,13 @@ func TestInsertReportsNilNestedValueError(t *testing.T) {
 // particular option set it explicitly instead.
 // writeTempDB serializes the tree to a file in the test's temp directory and
 // returns its path. The directory is removed when the test ends.
-func writeTempDB(t *testing.T, tree *Tree) string {
-	t.Helper()
-	file, err := os.CreateTemp(t.TempDir(), "mmdbwriter-*.mmdb")
-	require.NoError(t, err)
+func writeTempDB(tb testing.TB, tree *Tree) string {
+	tb.Helper()
+	file, err := os.CreateTemp(tb.TempDir(), "mmdbwriter-*.mmdb")
+	require.NoError(tb, err)
 	_, err = tree.WriteTo(file)
-	require.NoError(t, err)
-	require.NoError(t, file.Close())
+	require.NoError(tb, err)
+	require.NoError(tb, file.Close())
 	return file.Name()
 }
 

--- a/tree_test.go
+++ b/tree_test.go
@@ -165,7 +165,7 @@ func TestPanickingInserterReleasesItsReferences(t *testing.T) {
 		tree.InsertPureFunc(
 			netip.MustParsePrefix("1.0.0.0/24"),
 			mmdbtype.Map{"name": mmdbtype.String("new")},
-			func(existing, _ mmdbtype.DataType, _ inserter.Metadata) (mmdbtype.DataType, error) {
+			func(existing, _ mmdbtype.DataType) (mmdbtype.DataType, error) {
 				calls++
 				if calls == 2 {
 					panic("inserter failure")
@@ -203,7 +203,7 @@ func TestPanickingRangeInserterReleasesItsReferences(t *testing.T) {
 			netip.MustParseAddr("1.0.0.0"),
 			netip.MustParseAddr("1.0.0.255"),
 			mmdbtype.Map{"name": mmdbtype.String("new")},
-			func(existing, _ mmdbtype.DataType, _ inserter.Metadata) (mmdbtype.DataType, error) {
+			func(existing, _ mmdbtype.DataType) (mmdbtype.DataType, error) {
 				calls++
 				if calls == 2 {
 					panic("inserter failure")
@@ -326,7 +326,7 @@ func TestTreeNodeBlocksGrowAndWrite(t *testing.T) {
 	}
 }
 
-func TestTreeInsertFunc(t *testing.T) {
+func TestTreeInsertPureFunc(t *testing.T) {
 	tree, err := New(Options{
 		IPVersion:               4,
 		IncludeReservedNetworks: true,
@@ -339,7 +339,7 @@ func TestTreeInsertFunc(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	err = tree.InsertFunc(
+	err = tree.InsertPureFunc(
 		netip.MustParsePrefix("1.2.3.0/25"),
 		mmdbtype.Map{"extra": mmdbtype.String("value")},
 		inserter.TopLevelMerge,
@@ -367,7 +367,7 @@ func TestTreeInsertPureFuncMemoizesDistinctExistingValues(t *testing.T) {
 	err = tree.InsertPureFunc(
 		netip.MustParsePrefix("1.2.3.0/24"),
 		mmdbtype.String("new"),
-		func(existing, newValue mmdbtype.DataType, _ inserter.Metadata) (mmdbtype.DataType, error) {
+		func(existing, newValue mmdbtype.DataType) (mmdbtype.DataType, error) {
 			calls[existing.(mmdbtype.String)]++
 			return newValue, nil
 		},
@@ -413,7 +413,7 @@ func TestTreeInsertPureFuncReleasesMemoAfterPartialError(t *testing.T) {
 	err = tree.InsertPureFunc(
 		netip.MustParsePrefix("1.2.3.0/24"),
 		mmdbtype.String("new"),
-		func(existing, _ mmdbtype.DataType, _ inserter.Metadata) (mmdbtype.DataType, error) {
+		func(existing, _ mmdbtype.DataType) (mmdbtype.DataType, error) {
 			if existing == mmdbtype.String("second") {
 				return nil, insertErr
 			}
@@ -506,13 +506,14 @@ func TestTreeRejectsNilInserterFunc(t *testing.T) {
 	require.NoError(t, err)
 
 	var insertFunc inserter.Func
+	var pureFunc inserter.PureFunc
 	prefix := netip.MustParsePrefix("1.2.3.0/24")
 	start := netip.MustParseAddr("1.2.3.1")
 	end := netip.MustParseAddr("1.2.3.2")
 	value := mmdbtype.String("value")
 
 	require.ErrorIs(t, tree.InsertFunc(prefix, value, insertFunc), errNilInserterFunc)
-	require.ErrorIs(t, tree.InsertPureFunc(prefix, value, insertFunc), errNilInserterFunc)
+	require.ErrorIs(t, tree.InsertPureFunc(prefix, value, pureFunc), errNilInserterFunc)
 	require.ErrorIs(
 		t,
 		tree.InsertRangeFunc(start, end, value, insertFunc),
@@ -520,7 +521,7 @@ func TestTreeRejectsNilInserterFunc(t *testing.T) {
 	)
 	require.ErrorIs(
 		t,
-		tree.InsertRangePureFunc(start, end, value, insertFunc),
+		tree.InsertRangePureFunc(start, end, value, pureFunc),
 		errNilInserterFunc,
 	)
 }
@@ -831,7 +832,7 @@ func TestTreeInsertRangeInvalidBounds(t *testing.T) {
 	}
 }
 
-func TestTreeInsertRangeFuncNonPrefixAligned(t *testing.T) {
+func TestTreeInsertRangePureFuncNonPrefixAligned(t *testing.T) {
 	tree, err := New(Options{IPVersion: 4, IncludeReservedNetworks: true})
 	require.NoError(t, err)
 
@@ -841,7 +842,7 @@ func TestTreeInsertRangeFuncNonPrefixAligned(t *testing.T) {
 		"extra": mmdbtype.String("value"),
 	}
 	require.NoError(t, tree.Insert(netip.MustParsePrefix("1.2.3.0/24"), base))
-	require.NoError(t, tree.InsertRangeFunc(
+	require.NoError(t, tree.InsertRangePureFunc(
 		netip.MustParseAddr("1.2.3.10"),
 		netip.MustParseAddr("1.2.3.20"),
 		mmdbtype.Map{"extra": mmdbtype.String("value")},
@@ -875,7 +876,7 @@ func TestTreeInsertRangePureFuncMemoizesAcrossSubnets(t *testing.T) {
 		netip.MustParseAddr("1.2.3.1"),
 		netip.MustParseAddr("1.2.3.254"),
 		newValue,
-		func(existing, replacement mmdbtype.DataType, _ inserter.Metadata) (mmdbtype.DataType, error) {
+		func(existing, replacement mmdbtype.DataType) (mmdbtype.DataType, error) {
 			calls++
 			assert.Equal(t, oldValue, existing)
 			return replacement, nil
@@ -2133,7 +2134,7 @@ func TestInsertFunc_RemovalAndLaterInsert(t *testing.T) {
 
 	removedNetwork := netip.MustParsePrefix("::1.1.1.1/128")
 
-	err = tree.InsertFunc(
+	err = tree.InsertPureFunc(
 		removedNetwork,
 		nil,
 		inserter.Remove,
@@ -2197,7 +2198,7 @@ func TestInsertPureFuncEqualResultKeepsReference(t *testing.T) {
 	require.NoError(t, tree.InsertPureFunc(
 		prefix,
 		mmdbtype.String("value"),
-		func(existingValue, _ mmdbtype.DataType, _ inserter.Metadata) (mmdbtype.DataType, error) {
+		func(existingValue, _ mmdbtype.DataType) (mmdbtype.DataType, error) {
 			return existingValue, nil
 		},
 	))
@@ -2271,7 +2272,16 @@ func TestInsertPureFuncMatchesInsertFuncOutput(t *testing.T) {
 		if pure {
 			require.NoError(t, tree.InsertPureFunc(prefix, value, inserter.DeepMerge))
 		} else {
-			require.NoError(t, tree.InsertFunc(prefix, value, inserter.DeepMerge))
+			require.NoError(t, tree.InsertFunc(
+				prefix,
+				value,
+				func(existingValue, newValue mmdbtype.DataType, _ inserter.Metadata) (
+					mmdbtype.DataType,
+					error,
+				) {
+					return inserter.DeepMerge(existingValue, newValue)
+				},
+			))
 		}
 
 		var buf bytes.Buffer
@@ -2445,7 +2455,7 @@ func TestSignedZeroIsNeverSilentlyDropped(t *testing.T) {
 				"zero":    mmdbtype.Float64(0),
 				"sibling": mmdbtype.String("same"),
 			}))
-			require.NoError(t, tree.InsertFunc(prefix, test.newValue, inserter.DeepMerge))
+			require.NoError(t, tree.InsertPureFunc(prefix, test.newValue, inserter.DeepMerge))
 
 			_, value := tree.Get(netip.MustParseAddr("1.2.3.4"))
 			stored := float64(value.(mmdbtype.Map)["zero"].(mmdbtype.Float64))
@@ -2580,7 +2590,9 @@ func TestInserterNilResultOverEmptySpaceIsNoOp(t *testing.T) {
 				return tree.InsertFunc(
 					netip.MustParsePrefix("9.9.9.0/24"),
 					mmdbtype.String("ignored"),
-					inserter.Remove,
+					func(_, _ mmdbtype.DataType, _ inserter.Metadata) (mmdbtype.DataType, error) {
+						return nil, nil
+					},
 				)
 			},
 		},

--- a/value_store_test.go
+++ b/value_store_test.go
@@ -645,7 +645,7 @@ func TestMemoPinsItsKeys(t *testing.T) {
 	firstResult, err := store.internUncached(mmdbtype.String("first result"))
 	require.NoError(t, err)
 
-	iRec := &insertRecord{store: store, inserterPure: true}
+	iRec := &insertRecord{store: store}
 	iRec.rememberResolved(first, firstResult)
 	assert.Equal(t, uint32(2), store.nodes[first].refCount,
 		"the memo did not pin its key")

--- a/value_store_test.go
+++ b/value_store_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/maxmind/mmdbwriter/v2/inserter"
 	"github.com/maxmind/mmdbwriter/v2/mmdbtype"
 )
 
@@ -645,7 +646,11 @@ func TestMemoPinsItsKeys(t *testing.T) {
 	firstResult, err := store.internUncached(mmdbtype.String("first result"))
 	require.NoError(t, err)
 
-	iRec := &insertRecord{store: store}
+	// Only a pure inserter is memoized, so the fixture carries one.
+	iRec := &insertRecord{
+		store:    store,
+		resolver: insertResolver{pure: inserter.Replace},
+	}
 	iRec.rememberResolved(first, firstResult)
 	assert.Equal(t, uint32(2), store.nodes[first].refCount,
 		"the memo did not pin its key")


### PR DESCRIPTION
## Summary

- add `inserter.Metadata` for explicit `Tree.InsertFunc` and
  `Tree.InsertRangeFunc` callbacks, including normalized insertion and current
  record-shape information
- add a separate two-argument `inserter.PureFunc` for `Options.Inserter`, the
  default insert/range/load paths, the pure insert methods, and all built-in
  inserters; repeated value pairs may be memoized without exposing metadata
- restore logically identical record extents when a callback fails before
  installing a result, and share tree-address decoding in `internal/treeaddr`
- add current-shape, range, load, IPv4/IPv6, retry, malformed-metadata,
  differential, memoization, and oracle-fuzz coverage

## Performance

- no timing benchmark had a statistically significant regression; the original
  nine-benchmark comparison against `main` had a 0.34% faster geomean
- the metadata overlay workflow was 33.68% faster, allocated 24.60% fewer bytes,
  and performed 31.84% fewer allocations than sort-plus-provenance-plus-strip
  (`p < 0.001`, 10 samples)
- a follow-up comparison of pure overlapping inserts, Enterprise load plus
  overlay, and metadata overlays found unchanged allocation counts and no
  significant timing changes after splitting the callback types
- a fixed-epoch Enterprise load/rewrite was byte-identical before and after the
  change

## Testing

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `GOARCH=386 go test ./...`
- `MMDBWRITER_REFCOUNT_AUDIT=1 go test ./...`
- `go test -run='^$' -fuzz='^FuzzInserterMetadata$' -fuzztime=30s .`
- tracked Go and Markdown files formatted and linted at every commit snapshot
- counterbalanced `benchstat` comparison with 10 samples per revision, plus a
  targeted five-sample before/after comparison for the callback-type split


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added metadata-aware insertion callbacks with inserted-network, existing-record, and tree-depth details.
  * Added dedicated pure insertion APIs for records and ranges.
  * Added metadata helpers and memoization for repeated pure insertion values.

* **Improvements**
  * Improved IPv4, IPv6, range insertion, and network normalization support.
  * Clarified rollback, partial-success, and error-handling behavior.

* **Breaking Changes**
  * Updated callback signatures and simplified replacement and merge API names.
  * Removed the former function generator API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->